### PR TITLE
feat(indicators): add EMA, MACD, slope, and ATR indicator library

### DIFF
--- a/crates/bot/src/indicators/ema.rs
+++ b/crates/bot/src/indicators/ema.rs
@@ -1,0 +1,86 @@
+/// Computes EMA over a f64 series. Returns Vec<f64> same length.
+/// For bars where EMA is not yet computable (i < period-1), returns series[i] (SMA seed).
+/// Input: data in chronological order (oldest first).
+pub fn compute(data: &[f64], period: usize) -> Vec<f64> {
+    if data.is_empty() || period == 0 {
+        return vec![];
+    }
+    if period > data.len() {
+        return data.to_vec();
+    }
+
+    let n = data.len();
+    let alpha = 2.0 / (period as f64 + 1.0);
+    let mut result = vec![0.0f64; n];
+
+    // Echo raw values before the SMA seed window is full
+    for (i, &v) in data[..period - 1].iter().enumerate() {
+        result[i] = v;
+    }
+
+    // Seed with SMA of first `period` values
+    result[period - 1] = data[..period].iter().sum::<f64>() / period as f64;
+
+    // Apply EMA formula for remaining bars
+    for i in period..n {
+        result[i] = alpha * data[i] + (1.0 - alpha) * result[i - 1];
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ema_length() {
+        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
+        let ema = compute(&data, 3);
+        assert_eq!(ema.len(), data.len());
+    }
+
+    #[test]
+    fn test_ema_convergence() {
+        let data = vec![5.0; 20];
+        let ema = compute(&data, 5);
+        for &v in &ema[4..] {
+            assert!((v - 5.0).abs() < 1e-10, "EMA should converge to constant value");
+        }
+    }
+
+    #[test]
+    fn test_ema_seed_values() {
+        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        let ema = compute(&data, 3);
+        assert_eq!(ema[0], data[0]);
+        assert_eq!(ema[1], data[1]);
+        let expected_seed = (1.0 + 2.0 + 3.0) / 3.0;
+        assert!((ema[2] - expected_seed).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_ema_empty() {
+        let ema = compute(&[], 5);
+        assert!(ema.is_empty());
+    }
+
+    #[test]
+    fn test_ema_period_larger_than_data() {
+        let data = vec![1.0, 2.0];
+        let ema = compute(&data, 5);
+        assert_eq!(ema.len(), data.len());
+        assert_eq!(ema[0], data[0]);
+        assert_eq!(ema[1], data[1]);
+    }
+
+    #[test]
+    fn test_ema_period_one() {
+        let data = vec![1.0, 2.0, 3.0, 4.0];
+        let ema = compute(&data, 1);
+        // alpha = 1.0 when period = 1, so EMA collapses to the data itself
+        for (e, d) in ema.iter().zip(data.iter()) {
+            assert!((e - d).abs() < 1e-10);
+        }
+    }
+}

--- a/crates/bot/src/indicators/macd.rs
+++ b/crates/bot/src/indicators/macd.rs
@@ -1,0 +1,150 @@
+use crate::market_data::Candle;
+use super::{ema, slope};
+
+pub struct MacdResult {
+    /// MACD line = EMA(fast) - EMA(slow), chronological order (oldest first), len = candles.len()
+    pub macd_line: Vec<f64>,
+    /// Signal line = EMA(macd_line, signal_period), same len
+    pub signal_line: Vec<f64>,
+    /// Histogram = macd_line - signal_line, same len
+    pub histogram: Vec<f64>,
+    /// histogram[i] / close_prices[i]
+    pub normalized_histogram: Vec<f64>,
+}
+
+/// Computes MACD from candles (newest-first input → internally reversed to oldest-first).
+/// Returns MacdResult in chronological order (oldest first).
+pub fn compute(candles: &[Candle], fast: usize, slow: usize, signal: usize) -> MacdResult {
+    if candles.is_empty() {
+        return MacdResult {
+            macd_line: vec![],
+            signal_line: vec![],
+            histogram: vec![],
+            normalized_histogram: vec![],
+        };
+    }
+
+    let close_prices: Vec<f64> = candles.iter().rev().map(|c| c.close as f64 / 100.0).collect();
+
+    let ema_fast = ema::compute(&close_prices, fast);
+    let ema_slow = ema::compute(&close_prices, slow);
+
+    let macd_line: Vec<f64> = ema_fast.iter().zip(&ema_slow).map(|(f, s)| f - s).collect();
+    let signal_line = ema::compute(&macd_line, signal);
+    let histogram: Vec<f64> = macd_line.iter().zip(&signal_line).map(|(m, s)| m - s).collect();
+
+    let normalized_histogram: Vec<f64> = histogram
+        .iter()
+        .zip(&close_prices)
+        .map(|(&h, &c)| if c == 0.0 { 0.0 } else { h / c })
+        .collect();
+
+    MacdResult { macd_line, signal_line, histogram, normalized_histogram }
+}
+
+pub struct SlopeAnalysis {
+    pub macd_slope: Vec<f64>,
+    pub signal_slope: Vec<f64>,
+    pub histogram_slope: Vec<f64>,
+    pub histogram_acceleration: Vec<f64>,
+}
+
+/// Computes slope analysis from a MacdResult.
+/// All slopes are per-bar rate of change, normalized by close price.
+pub fn compute_slope_analysis(
+    result: &MacdResult,
+    close_prices: &[f64],
+    lookback: usize,
+) -> SlopeAnalysis {
+    let normalize = |raw: Vec<f64>| -> Vec<f64> {
+        raw.iter()
+            .zip(close_prices)
+            .map(|(&s, &c)| if c == 0.0 { 0.0 } else { s / c })
+            .collect()
+    };
+
+    SlopeAnalysis {
+        macd_slope:             normalize(slope::compute(&result.macd_line,  lookback)),
+        signal_slope:           normalize(slope::compute(&result.signal_line, lookback)),
+        histogram_slope:        normalize(slope::compute(&result.histogram,   lookback)),
+        histogram_acceleration: normalize(slope::compute_acceleration(&result.histogram, lookback)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn make_candles(closes: &[i64]) -> Vec<Candle> {
+        closes.iter().rev().map(|&c| Candle {
+            timestamp: Utc::now(),
+            open: c, high: c + 10, low: c - 10, close: c, volume: 1000,
+        }).collect()
+    }
+
+    #[test]
+    fn test_macd_histogram_equals_macd_minus_signal() {
+        let closes: Vec<i64> = (1..=50).map(|i| i * 100).collect();
+        let result = compute(&make_candles(&closes), 12, 26, 9);
+
+        assert_eq!(result.macd_line.len(), closes.len());
+        assert_eq!(result.signal_line.len(), closes.len());
+        assert_eq!(result.histogram.len(), closes.len());
+
+        for i in 0..result.histogram.len() {
+            let expected = result.macd_line[i] - result.signal_line[i];
+            assert!(
+                (result.histogram[i] - expected).abs() < 1e-10,
+                "histogram[{i}] mismatch: {} != {expected}", result.histogram[i],
+            );
+        }
+    }
+
+    #[test]
+    fn test_macd_normalized_histogram() {
+        let closes: Vec<i64> = (100..=150).map(|i| i * 100).collect();
+        let result = compute(&make_candles(&closes), 3, 5, 2);
+        let close_prices: Vec<f64> = closes.iter().map(|&c| c as f64 / 100.0).collect();
+
+        for (i, (&norm, &close)) in result.normalized_histogram.iter().zip(&close_prices).enumerate() {
+            if close != 0.0 {
+                let expected = result.histogram[i] / close;
+                assert!((norm - expected).abs() < 1e-10, "normalized_histogram[{i}] mismatch");
+            }
+        }
+    }
+
+    #[test]
+    fn test_macd_lengths() {
+        let closes: Vec<i64> = (1..=30).map(|i| i * 100).collect();
+        let result = compute(&make_candles(&closes), 3, 5, 2);
+
+        assert_eq!(result.macd_line.len(), closes.len());
+        assert_eq!(result.signal_line.len(), closes.len());
+        assert_eq!(result.histogram.len(), closes.len());
+        assert_eq!(result.normalized_histogram.len(), closes.len());
+    }
+
+    #[test]
+    fn test_macd_empty_candles() {
+        let result = compute(&[], 12, 26, 9);
+        assert!(result.macd_line.is_empty());
+        assert!(result.signal_line.is_empty());
+        assert!(result.histogram.is_empty());
+        assert!(result.normalized_histogram.is_empty());
+    }
+
+    #[test]
+    fn test_slope_analysis_lengths() {
+        let closes: Vec<i64> = (1..=30).map(|i| i * 100).collect();
+        let result = compute(&make_candles(&closes), 3, 5, 2);
+        let close_prices: Vec<f64> = closes.iter().map(|&c| c as f64 / 100.0).collect();
+
+        let analysis = compute_slope_analysis(&result, &close_prices, 3);
+        assert_eq!(analysis.macd_slope.len(), closes.len());
+        assert_eq!(analysis.signal_slope.len(), closes.len());
+        assert_eq!(analysis.histogram_slope.len(), closes.len());
+        assert_eq!(analysis.histogram_acceleration.len(), closes.len());
+    }
+}

--- a/crates/bot/src/indicators/mod.rs
+++ b/crates/bot/src/indicators/mod.rs
@@ -1,0 +1,7 @@
+pub mod ema;
+pub mod macd;
+pub mod slope;
+
+pub use ema::compute as compute_ema;
+pub use macd::{compute as compute_macd, MacdResult, SlopeAnalysis};
+pub use slope::{compute as compute_slope, compute_acceleration, compute_atr};

--- a/crates/bot/src/indicators/slope.rs
+++ b/crates/bot/src/indicators/slope.rs
@@ -1,0 +1,153 @@
+use crate::market_data::Candle;
+use super::ema;
+
+/// Returns slope of a linear regression over the last `lookback` values ending at index i.
+/// For i < lookback-1, returns 0.0.
+/// Input: chronological order (oldest first).
+pub fn compute(series: &[f64], lookback: usize) -> Vec<f64> {
+    let n = series.len();
+    let mut result = vec![0.0f64; n];
+
+    if lookback < 2 || n < lookback {
+        return result;
+    }
+
+    for i in (lookback - 1)..n {
+        let window = &series[(i + 1 - lookback)..=i];
+        result[i] = linear_regression_slope(window);
+    }
+
+    result
+}
+
+/// Returns second derivative (slope of slope).
+pub fn compute_acceleration(series: &[f64], lookback: usize) -> Vec<f64> {
+    let slopes = compute(series, lookback);
+    compute(&slopes, lookback)
+}
+
+/// Compute True Range for each candle. Returns Vec<f64> same length. Oldest first.
+/// Candle input is newest-first → internally reverse.
+pub fn compute_atr(candles: &[Candle], period: usize) -> Vec<f64> {
+    if candles.is_empty() {
+        return vec![];
+    }
+
+    let n = candles.len();
+    let mut tr = vec![0.0f64; n];
+
+    // Candles come newest-first; iterate in reverse (oldest-first) for TR calculation
+    let ordered: Vec<&Candle> = candles.iter().rev().collect();
+
+    // First bar: no previous close, TR = high - low
+    tr[0] = (ordered[0].high - ordered[0].low) as f64 / 100.0;
+
+    for i in 1..n {
+        let high      = ordered[i].high  as f64 / 100.0;
+        let low       = ordered[i].low   as f64 / 100.0;
+        let prev_close = ordered[i - 1].close as f64 / 100.0;
+        tr[i] = (high - low).max((high - prev_close).abs()).max((low - prev_close).abs());
+    }
+
+    ema::compute(&tr, period)
+}
+
+/// slope = Σ((x - x̄)(y - ȳ)) / Σ((x - x̄)²), where x ∈ {0, 1, …, n-1}
+fn linear_regression_slope(window: &[f64]) -> f64 {
+    let n = window.len();
+    if n < 2 {
+        return 0.0;
+    }
+
+    let x_mean = (n as f64 - 1.0) / 2.0;
+    let y_mean: f64 = window.iter().sum::<f64>() / n as f64;
+
+    let (num, den) = window.iter().enumerate().fold((0.0f64, 0.0f64), |(num, den), (i, &y)| {
+        let dx = i as f64 - x_mean;
+        (num + dx * (y - y_mean), den + dx * dx)
+    });
+
+    if den == 0.0 { 0.0 } else { num / den }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_slope_linear_series() {
+        // y = 2x + 1 → slope must be exactly 2.0
+        let data: Vec<f64> = (0..10).map(|i| 2.0 * i as f64 + 1.0).collect();
+        let slopes = compute(&data, 4);
+        for &s in &slopes[3..] {
+            assert!((s - 2.0).abs() < 1e-8, "Expected slope ~2.0, got {}", s);
+        }
+    }
+
+    #[test]
+    fn test_slope_constant_series() {
+        let data = vec![5.0; 10];
+        let slopes = compute(&data, 3);
+        for &s in &slopes[2..] {
+            assert!(s.abs() < 1e-10, "Expected slope ~0.0, got {}", s);
+        }
+    }
+
+    #[test]
+    fn test_slope_length() {
+        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        assert_eq!(compute(&data, 3).len(), data.len());
+    }
+
+    #[test]
+    fn test_slope_early_values_are_zero() {
+        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        let slopes = compute(&data, 3);
+        assert_eq!(slopes[0], 0.0);
+        assert_eq!(slopes[1], 0.0);
+    }
+
+    #[test]
+    fn test_acceleration_length() {
+        let data: Vec<f64> = (0..20).map(|i| i as f64).collect();
+        assert_eq!(compute_acceleration(&data, 3).len(), data.len());
+    }
+
+    #[test]
+    fn test_atr_length() {
+        use chrono::Utc;
+        // Build newest-first candles
+        let candles: Vec<Candle> = (0..10i64)
+            .rev()
+            .map(|i| Candle {
+                timestamp: Utc::now(),
+                open:   10000 + i * 10,
+                high:   10100 + i * 10,
+                low:    9900  + i * 10,
+                close:  10050 + i * 10,
+                volume: 1000,
+            })
+            .collect();
+        assert_eq!(compute_atr(&candles, 3).len(), candles.len());
+    }
+
+    #[test]
+    fn test_atr_positive_values() {
+        use chrono::Utc;
+        let candles: Vec<Candle> = (0..10i64)
+            .rev()
+            .map(|i| Candle {
+                timestamp: Utc::now(),
+                open:   10000 + i * 10,
+                high:   10100 + i * 10,
+                low:    9900  + i * 10,
+                close:  10050 + i * 10,
+                volume: 1000,
+            })
+            .collect();
+        let atr = compute_atr(&candles, 3);
+        for &v in &atr[2..] {
+            assert!(v > 0.0, "ATR should be positive, got {}", v);
+        }
+    }
+}

--- a/crates/bot/src/lib.rs
+++ b/crates/bot/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod collector;
 pub mod config;
 pub mod db;
+pub mod indicators;
 pub mod market_data;
 pub mod metrics;
 pub mod optimizer;


### PR DESCRIPTION
## Summary
- Adds `indicators/` module with pure-math implementations of EMA, MACD, slope analysis, and ATR
- EMA with SMA seed; MACD with normalized histogram; linear regression slope/acceleration; ATR via True Range EMA
- 18 unit tests covering correctness of all indicator computations

## Test plan
- [x] `cargo build -p bot` passes
- [x] `cargo test -p bot --lib` passes (18 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)