### PR TITLE
Runtime-managed risk exits

### DIFF
--- a/backtester/src/lib.rs
+++ b/backtester/src/lib.rs
@@ -537,6 +537,8 @@ mod tests {
         assert!(m.peak_equity > 1_000.0);
     }
 
+    // Legacy donor coverage for the old backtester executor. Runtime-managed
+    // Risk Exit price semantics are source-of-truth in trading-runtime tests.
     #[test]
     fn stop_loss_closes_long() {
         let mut e = InMemoryExecutor::new(1_000.0);

--- a/trading-runtime/src/events.rs
+++ b/trading-runtime/src/events.rs
@@ -1,8 +1,8 @@
 //! Ordered, runner-neutral events emitted by the trading runtime.
 
 use crate::{
-    ClosedPosition, ExecutionAction, IgnoredDecisionReason, RiskExitKind, RuntimePortfolioSnapshot,
-    StrategyDecision,
+    ClosedPosition, ExecutionAction, IgnoredDecisionReason, RiskExitKind, RiskExitTriggered,
+    RuntimePortfolioSnapshot, StrategyDecision,
 };
 use shared::{Candle, Position};
 
@@ -41,6 +41,9 @@ pub enum RuntimeEvent {
     StrategyDecisionIgnored {
         decision: StrategyDecision,
         reason: IgnoredDecisionReason,
+    },
+    RiskExitTriggered {
+        risk_exit: RiskExitTriggered,
     },
     PositionOpened {
         position: Position,

--- a/trading-runtime/src/events.rs
+++ b/trading-runtime/src/events.rs
@@ -26,6 +26,9 @@ pub enum RuntimeEvent {
     MarketInputAccepted {
         candle: Candle,
     },
+    WarmupInputAccepted {
+        candle: Candle,
+    },
     TradableTickStarted {
         candle: Candle,
     },
@@ -51,11 +54,11 @@ pub enum RuntimeEvent {
     },
     TradableTickCompleted,
     WarmupAdvanced {
-        current_primary_candle_count: usize,
-        required_warmup_candles: usize,
+        current_warmup_input_count: usize,
+        required_warmup_inputs: usize,
     },
     WarmupCompleted {
-        completed_primary_candle_count: usize,
+        completed_warmup_input_count: usize,
     },
     ForceCloseRequested {
         candle: Candle,

--- a/trading-runtime/src/events.rs
+++ b/trading-runtime/src/events.rs
@@ -1,7 +1,7 @@
 //! Ordered, runner-neutral events emitted by the trading runtime.
 
 use crate::{
-    ClosedPosition, ExecutionAction, IgnoredDecisionReason, RuntimePortfolioSnapshot,
+    ClosedPosition, ExecutionAction, IgnoredDecisionReason, RiskExitKind, RuntimePortfolioSnapshot,
     StrategyDecision,
 };
 use shared::{Candle, Position};
@@ -10,6 +10,14 @@ use shared::{Candle, Position};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ForceCloseIgnoredReason {
     NoOpenPosition,
+}
+
+/// Machine-readable category for a position-closing portfolio transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitKind {
+    StrategyExit,
+    RiskExit { selected: RiskExitKind },
+    ForceClose,
 }
 
 /// A runner-neutral occurrence emitted by the trading runtime.
@@ -36,6 +44,7 @@ pub enum RuntimeEvent {
     },
     PositionClosed {
         closed_position: ClosedPosition,
+        exit_kind: ExitKind,
     },
     PortfolioUpdated {
         snapshot: RuntimePortfolioSnapshot,

--- a/trading-runtime/src/execution.rs
+++ b/trading-runtime/src/execution.rs
@@ -26,6 +26,7 @@ pub enum ExecutionAction {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IgnoredDecisionReason {
     InvalidQuantity,
+    InvalidEntryRisk,
     NoMatchingLongPosition,
     NoMatchingShortPosition,
     PositionAlreadyOpen,
@@ -65,15 +66,20 @@ impl PlannedExecution {
 pub fn plan_execution(
     decision: &StrategyDecision,
     current_side: Option<PositionSide>,
+    entry_price: f64,
 ) -> PlannedExecution {
     match decision.intent {
         StrategyDecisionIntent::Hold => PlannedExecution::noop(),
-        StrategyDecisionIntent::OpenLong => plan_open_long(decision, current_side),
+        StrategyDecisionIntent::OpenLong => {
+            plan_open(decision, current_side, PositionSide::Long, entry_price)
+        }
         StrategyDecisionIntent::CloseLong => match current_side {
             Some(PositionSide::Long) => PlannedExecution::action(ExecutionAction::CloseLong),
             _ => PlannedExecution::ignored(IgnoredDecisionReason::NoMatchingLongPosition),
         },
-        StrategyDecisionIntent::OpenShort => plan_open_short(decision, current_side),
+        StrategyDecisionIntent::OpenShort => {
+            plan_open(decision, current_side, PositionSide::Short, entry_price)
+        }
         StrategyDecisionIntent::CloseShort => match current_side {
             Some(PositionSide::Short) => PlannedExecution::action(ExecutionAction::CloseShort),
             _ => PlannedExecution::ignored(IgnoredDecisionReason::NoMatchingShortPosition),
@@ -81,41 +87,85 @@ pub fn plan_execution(
     }
 }
 
-fn plan_open_long(
+fn plan_open(
     decision: &StrategyDecision,
     current_side: Option<PositionSide>,
+    opening_side: PositionSide,
+    entry_price: f64,
 ) -> PlannedExecution {
     if current_side.is_some() {
         return PlannedExecution::ignored(IgnoredDecisionReason::PositionAlreadyOpen);
     }
 
-    match decision.validated_opening_quantity() {
-        Ok(Some(quantity)) => PlannedExecution::action(ExecutionAction::OpenLong {
+    let quantity = match decision.validated_opening_quantity() {
+        Ok(Some(quantity)) => quantity,
+        Ok(None) | Err(_) => {
+            return PlannedExecution::ignored(IgnoredDecisionReason::InvalidQuantity)
+        }
+    };
+
+    if !entry_risk_is_valid(
+        opening_side,
+        entry_price,
+        decision.stop_loss,
+        decision.take_profit,
+    ) {
+        return PlannedExecution::ignored(IgnoredDecisionReason::InvalidEntryRisk);
+    }
+
+    match opening_side {
+        PositionSide::Long => PlannedExecution::action(ExecutionAction::OpenLong {
             quantity,
             stop_loss: decision.stop_loss,
             take_profit: decision.take_profit,
         }),
-        Ok(None) => PlannedExecution::ignored(IgnoredDecisionReason::InvalidQuantity),
-        Err(_) => PlannedExecution::ignored(IgnoredDecisionReason::InvalidQuantity),
+        PositionSide::Short => PlannedExecution::action(ExecutionAction::OpenShort {
+            quantity,
+            stop_loss: decision.stop_loss,
+            take_profit: decision.take_profit,
+        }),
     }
 }
 
-fn plan_open_short(
-    decision: &StrategyDecision,
-    current_side: Option<PositionSide>,
-) -> PlannedExecution {
-    if current_side.is_some() {
-        return PlannedExecution::ignored(IgnoredDecisionReason::PositionAlreadyOpen);
-    }
+fn entry_risk_is_valid(
+    side: PositionSide,
+    entry_price: f64,
+    stop_loss: Option<f64>,
+    take_profit: Option<f64>,
+) -> bool {
+    let stop_loss_is_valid = match stop_loss {
+        Some(stop_loss) => {
+            risk_price_is_valid(stop_loss)
+                && stop_loss_is_on_correct_side(side, stop_loss, entry_price)
+        }
+        None => true,
+    };
+    let take_profit_is_valid = match take_profit {
+        Some(take_profit) => {
+            risk_price_is_valid(take_profit)
+                && take_profit_is_on_correct_side(side, take_profit, entry_price)
+        }
+        None => true,
+    };
 
-    match decision.validated_opening_quantity() {
-        Ok(Some(quantity)) => PlannedExecution::action(ExecutionAction::OpenShort {
-            quantity,
-            stop_loss: decision.stop_loss,
-            take_profit: decision.take_profit,
-        }),
-        Ok(None) => PlannedExecution::ignored(IgnoredDecisionReason::InvalidQuantity),
-        Err(_) => PlannedExecution::ignored(IgnoredDecisionReason::InvalidQuantity),
+    stop_loss_is_valid && take_profit_is_valid
+}
+
+fn risk_price_is_valid(price: f64) -> bool {
+    price.is_finite() && price > 0.0
+}
+
+fn stop_loss_is_on_correct_side(side: PositionSide, stop_loss: f64, entry_price: f64) -> bool {
+    match side {
+        PositionSide::Long => stop_loss < entry_price,
+        PositionSide::Short => stop_loss > entry_price,
+    }
+}
+
+fn take_profit_is_on_correct_side(side: PositionSide, take_profit: f64, entry_price: f64) -> bool {
+    match side {
+        PositionSide::Long => take_profit > entry_price,
+        PositionSide::Short => take_profit < entry_price,
     }
 }
 
@@ -128,7 +178,7 @@ mod tests {
         current_side: Option<PositionSide>,
         expected: PlannedExecution,
     ) {
-        assert_eq!(plan_execution(&decision, current_side), expected);
+        assert_eq!(plan_execution(&decision, current_side, 100.0), expected);
     }
 
     #[test]
@@ -251,5 +301,60 @@ mod tests {
                 PlannedExecution::ignored(IgnoredDecisionReason::InvalidQuantity),
             );
         }
+    }
+
+    #[test]
+    fn invalid_entry_risk_is_ignored_after_quantity_validation() {
+        for decision in [
+            StrategyDecision::open_long(2.0).with_entry_risk(Some(f64::NAN), None),
+            StrategyDecision::open_long(2.0).with_entry_risk(Some(f64::INFINITY), None),
+            StrategyDecision::open_long(2.0).with_entry_risk(Some(0.0), None),
+            StrategyDecision::open_long(2.0).with_entry_risk(Some(-1.0), None),
+            StrategyDecision::open_long(2.0).with_entry_risk(Some(100.0), None),
+            StrategyDecision::open_long(2.0).with_entry_risk(Some(101.0), None),
+            StrategyDecision::open_long(2.0).with_entry_risk(None, Some(f64::NAN)),
+            StrategyDecision::open_long(2.0).with_entry_risk(None, Some(f64::INFINITY)),
+            StrategyDecision::open_long(2.0).with_entry_risk(None, Some(0.0)),
+            StrategyDecision::open_long(2.0).with_entry_risk(None, Some(-1.0)),
+            StrategyDecision::open_long(2.0).with_entry_risk(None, Some(100.0)),
+            StrategyDecision::open_long(2.0).with_entry_risk(None, Some(99.0)),
+            StrategyDecision::open_short(2.0).with_entry_risk(Some(f64::NAN), None),
+            StrategyDecision::open_short(2.0).with_entry_risk(Some(f64::INFINITY), None),
+            StrategyDecision::open_short(2.0).with_entry_risk(Some(0.0), None),
+            StrategyDecision::open_short(2.0).with_entry_risk(Some(-1.0), None),
+            StrategyDecision::open_short(2.0).with_entry_risk(Some(100.0), None),
+            StrategyDecision::open_short(2.0).with_entry_risk(Some(99.0), None),
+            StrategyDecision::open_short(2.0).with_entry_risk(None, Some(f64::NAN)),
+            StrategyDecision::open_short(2.0).with_entry_risk(None, Some(f64::INFINITY)),
+            StrategyDecision::open_short(2.0).with_entry_risk(None, Some(0.0)),
+            StrategyDecision::open_short(2.0).with_entry_risk(None, Some(-1.0)),
+            StrategyDecision::open_short(2.0).with_entry_risk(None, Some(100.0)),
+            StrategyDecision::open_short(2.0).with_entry_risk(None, Some(101.0)),
+        ] {
+            assert_eq!(
+                plan_execution(&decision, None, 100.0),
+                PlannedExecution::ignored(IgnoredDecisionReason::InvalidEntryRisk),
+            );
+        }
+    }
+
+    #[test]
+    fn opening_validation_priority_is_state_then_quantity_then_entry_risk() {
+        assert_eq!(
+            plan_execution(
+                &StrategyDecision::open_long(0.0).with_entry_risk(Some(100.0), None),
+                Some(PositionSide::Short),
+                100.0,
+            ),
+            PlannedExecution::ignored(IgnoredDecisionReason::PositionAlreadyOpen),
+        );
+        assert_eq!(
+            plan_execution(
+                &StrategyDecision::open_long(0.0).with_entry_risk(Some(100.0), None),
+                None,
+                100.0,
+            ),
+            PlannedExecution::ignored(IgnoredDecisionReason::InvalidQuantity),
+        );
     }
 }

--- a/trading-runtime/src/execution.rs
+++ b/trading-runtime/src/execution.rs
@@ -1,9 +1,9 @@
-//! Pure planning from strategy decisions to runtime execution actions.
+//! Runtime execution action types and pure strategy-decision planning.
 
-use crate::{StrategyDecision, StrategyDecisionIntent};
+use crate::{RiskExitKind, StrategyDecision, StrategyDecisionIntent};
 use shared::PositionSide;
 
-/// Runtime interpretation of a strategy decision or explicit runner command.
+/// Runtime interpretation of a strategy decision or runtime-managed command.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ExecutionAction {
     Noop,
@@ -19,6 +19,11 @@ pub enum ExecutionAction {
         take_profit: Option<f64>,
     },
     CloseShort,
+    RiskExit {
+        side: PositionSide,
+        selected: RiskExitKind,
+        exit_price: f64,
+    },
     ForceClose,
 }
 

--- a/trading-runtime/src/lib.rs
+++ b/trading-runtime/src/lib.rs
@@ -15,6 +15,7 @@ pub mod decision;
 pub mod events;
 pub mod execution;
 pub mod portfolio;
+pub mod risk_exit;
 pub mod runtime;
 pub mod step;
 pub mod strategy;
@@ -27,6 +28,7 @@ pub use execution::{plan_execution, ExecutionAction, IgnoredDecisionReason, Plan
 pub use portfolio::{
     ClosedPosition, PortfolioState, PortfolioTransitionError, RuntimePortfolioSnapshot,
 };
+pub use risk_exit::{evaluate_risk_exit, RiskExitKind, RiskExitTriggered};
 pub use runtime::TradingRuntime;
 pub use step::RuntimeStep;
 pub use strategy::{PredeterminedStrategyHandler, StrategyHandler};

--- a/trading-runtime/src/lib.rs
+++ b/trading-runtime/src/lib.rs
@@ -23,7 +23,7 @@ pub mod strategy;
 pub use decision::{
     validate_opening_quantity, InvalidOpeningQuantity, StrategyDecision, StrategyDecisionIntent,
 };
-pub use events::{ForceCloseIgnoredReason, RuntimeEvent};
+pub use events::{ExitKind, ForceCloseIgnoredReason, RuntimeEvent};
 pub use execution::{plan_execution, ExecutionAction, IgnoredDecisionReason, PlannedExecution};
 pub use portfolio::{
     ClosedPosition, PortfolioState, PortfolioTransitionError, RuntimePortfolioSnapshot,

--- a/trading-runtime/src/portfolio.rs
+++ b/trading-runtime/src/portfolio.rs
@@ -41,7 +41,15 @@ impl PortfolioState {
         &mut self,
         candle: &Candle,
     ) -> Result<ClosedPosition, PortfolioTransitionError> {
-        self.close_matching_side(PositionSide::Long, candle)
+        self.close_long_at_price(candle, candle.close)
+    }
+
+    pub fn close_long_at_price(
+        &mut self,
+        candle: &Candle,
+        exit_price: f64,
+    ) -> Result<ClosedPosition, PortfolioTransitionError> {
+        self.close_matching_side(PositionSide::Long, candle, exit_price)
     }
 
     pub fn open_short_from_flat(
@@ -64,7 +72,15 @@ impl PortfolioState {
         &mut self,
         candle: &Candle,
     ) -> Result<ClosedPosition, PortfolioTransitionError> {
-        self.close_matching_side(PositionSide::Short, candle)
+        self.close_short_at_price(candle, candle.close)
+    }
+
+    pub fn close_short_at_price(
+        &mut self,
+        candle: &Candle,
+        exit_price: f64,
+    ) -> Result<ClosedPosition, PortfolioTransitionError> {
+        self.close_matching_side(PositionSide::Short, candle, exit_price)
     }
 
     fn open_from_flat(
@@ -96,6 +112,7 @@ impl PortfolioState {
         &mut self,
         expected_side: PositionSide,
         candle: &Candle,
+        exit_price: f64,
     ) -> Result<ClosedPosition, PortfolioTransitionError> {
         let position = self
             .open_position
@@ -110,7 +127,7 @@ impl PortfolioState {
         let pnl = realized_pnl(
             position.side,
             position.entry_price,
-            candle.close,
+            exit_price,
             position.size,
         );
         self.realized_cash_balance += pnl;
@@ -118,7 +135,7 @@ impl PortfolioState {
 
         Ok(ClosedPosition {
             position,
-            exit_price: candle.close,
+            exit_price,
             exit_time: candle.timestamp,
             realized_pnl: pnl,
         })
@@ -287,6 +304,28 @@ mod tests {
     }
 
     #[test]
+    fn closing_long_at_explicit_exit_price_uses_that_price_for_pnl_and_snapshot() {
+        let mut state = PortfolioState::new(1_000.0);
+        state
+            .open_long_from_flat(&candle(1, 100.0), 2.0, None, None)
+            .unwrap();
+        let exit_candle = candle(2, 115.0);
+
+        let closed = state.close_long_at_price(&exit_candle, 90.0).unwrap();
+        let snapshot = state.snapshot(exit_candle.close);
+
+        assert!(state.open_position.is_none());
+        assert_eq!(state.realized_cash_balance, 980.0);
+        assert_eq!(state.completed_trade_count, 1);
+        assert_eq!(closed.position.side, PositionSide::Long);
+        assert_eq!(closed.exit_price, 90.0);
+        assert_eq!(closed.exit_time, exit_candle.timestamp);
+        assert_eq!(closed.realized_pnl, -20.0);
+        assert!(snapshot.open_position.is_none());
+        assert_eq!(snapshot.current_equity, snapshot.realized_cash_balance);
+    }
+
+    #[test]
     fn opening_short_from_flat_creates_position_without_reducing_realized_cash() {
         let mut state = PortfolioState::new(1_000.0);
 
@@ -320,5 +359,27 @@ mod tests {
         assert_eq!(closed.exit_price, 85.0);
         assert_eq!(closed.exit_time, 2);
         assert_eq!(closed.realized_pnl, 30.0);
+    }
+
+    #[test]
+    fn closing_short_at_explicit_exit_price_uses_that_price_for_pnl_and_snapshot() {
+        let mut state = PortfolioState::new(1_000.0);
+        state
+            .open_short_from_flat(&candle(1, 100.0), 2.0, None, None)
+            .unwrap();
+        let exit_candle = candle(2, 85.0);
+
+        let closed = state.close_short_at_price(&exit_candle, 110.0).unwrap();
+        let snapshot = state.snapshot(exit_candle.close);
+
+        assert!(state.open_position.is_none());
+        assert_eq!(state.realized_cash_balance, 980.0);
+        assert_eq!(state.completed_trade_count, 1);
+        assert_eq!(closed.position.side, PositionSide::Short);
+        assert_eq!(closed.exit_price, 110.0);
+        assert_eq!(closed.exit_time, exit_candle.timestamp);
+        assert_eq!(closed.realized_pnl, -20.0);
+        assert!(snapshot.open_position.is_none());
+        assert_eq!(snapshot.current_equity, snapshot.realized_cash_balance);
     }
 }

--- a/trading-runtime/src/risk_exit.rs
+++ b/trading-runtime/src/risk_exit.rs
@@ -1,0 +1,148 @@
+//! Pure risk-exit selection and gap-aware pricing.
+
+use shared::{Candle, Position, PositionSide};
+
+/// Runtime-managed hard exit boundary selected from Entry Risk Parameters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RiskExitKind {
+    StopLoss,
+    TakeProfit,
+}
+
+/// Result of evaluating an open position's Entry Risk Parameters against one candle.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RiskExitTriggered {
+    pub side: PositionSide,
+    pub selected: RiskExitKind,
+    pub triggered: Vec<RiskExitKind>,
+    pub exit_price: f64,
+}
+
+/// Evaluate whether one already-open position is closed by its configured Entry Risk Parameters.
+///
+/// This function is pure: it only reads the open position and candle and never mutates Portfolio
+/// State. Open-gap triggers are evaluated before intrabar high/low touches because the candle open
+/// is the first known tradable price.
+pub fn evaluate_risk_exit(position: &Position, candle: &Candle) -> Option<RiskExitTriggered> {
+    match position.side {
+        PositionSide::Long => evaluate_long_risk_exit(position, candle),
+        PositionSide::Short => evaluate_short_risk_exit(position, candle),
+    }
+}
+
+fn evaluate_long_risk_exit(position: &Position, candle: &Candle) -> Option<RiskExitTriggered> {
+    if let Some(stop_loss) = position.stop_loss {
+        if candle.open <= stop_loss {
+            return Some(selected(
+                PositionSide::Long,
+                RiskExitKind::StopLoss,
+                candle.open,
+            ));
+        }
+    }
+
+    if let Some(take_profit) = position.take_profit {
+        if candle.open >= take_profit {
+            return Some(selected(
+                PositionSide::Long,
+                RiskExitKind::TakeProfit,
+                candle.open,
+            ));
+        }
+    }
+
+    let stop_loss_triggered = position
+        .stop_loss
+        .map(|stop_loss| candle.low <= stop_loss)
+        .unwrap_or(false);
+    let take_profit_triggered = position
+        .take_profit
+        .map(|take_profit| candle.high >= take_profit)
+        .unwrap_or(false);
+
+    intrabar_result(
+        PositionSide::Long,
+        stop_loss_triggered,
+        position.stop_loss,
+        take_profit_triggered,
+        position.take_profit,
+    )
+}
+
+fn evaluate_short_risk_exit(position: &Position, candle: &Candle) -> Option<RiskExitTriggered> {
+    if let Some(stop_loss) = position.stop_loss {
+        if candle.open >= stop_loss {
+            return Some(selected(
+                PositionSide::Short,
+                RiskExitKind::StopLoss,
+                candle.open,
+            ));
+        }
+    }
+
+    if let Some(take_profit) = position.take_profit {
+        if candle.open <= take_profit {
+            return Some(selected(
+                PositionSide::Short,
+                RiskExitKind::TakeProfit,
+                candle.open,
+            ));
+        }
+    }
+
+    let stop_loss_triggered = position
+        .stop_loss
+        .map(|stop_loss| candle.high >= stop_loss)
+        .unwrap_or(false);
+    let take_profit_triggered = position
+        .take_profit
+        .map(|take_profit| candle.low <= take_profit)
+        .unwrap_or(false);
+
+    intrabar_result(
+        PositionSide::Short,
+        stop_loss_triggered,
+        position.stop_loss,
+        take_profit_triggered,
+        position.take_profit,
+    )
+}
+
+fn intrabar_result(
+    side: PositionSide,
+    stop_loss_triggered: bool,
+    stop_loss: Option<f64>,
+    take_profit_triggered: bool,
+    take_profit: Option<f64>,
+) -> Option<RiskExitTriggered> {
+    match (stop_loss_triggered, take_profit_triggered) {
+        (true, true) => Some(RiskExitTriggered {
+            side,
+            selected: RiskExitKind::StopLoss,
+            triggered: vec![RiskExitKind::StopLoss, RiskExitKind::TakeProfit],
+            exit_price: stop_loss.expect("triggered stop-loss should have a configured price"),
+        }),
+        (true, false) => Some(RiskExitTriggered {
+            side,
+            selected: RiskExitKind::StopLoss,
+            triggered: vec![RiskExitKind::StopLoss],
+            exit_price: stop_loss.expect("triggered stop-loss should have a configured price"),
+        }),
+        (false, true) => Some(RiskExitTriggered {
+            side,
+            selected: RiskExitKind::TakeProfit,
+            triggered: vec![RiskExitKind::TakeProfit],
+            exit_price: take_profit.expect("triggered take-profit should have a configured price"),
+        }),
+        (false, false) => None,
+    }
+}
+
+fn selected(side: PositionSide, selected: RiskExitKind, exit_price: f64) -> RiskExitTriggered {
+    RiskExitTriggered {
+        side,
+        selected,
+        triggered: vec![selected],
+        exit_price,
+    }
+}

--- a/trading-runtime/src/runtime.rs
+++ b/trading-runtime/src/runtime.rs
@@ -1,8 +1,8 @@
 //! Trading runtime entrypoints.
 
 use crate::{
-    plan_execution, ExecutionAction, ExitKind, ForceCloseIgnoredReason, PortfolioState,
-    RuntimeEvent, RuntimeStep, StrategyHandler,
+    evaluate_risk_exit, plan_execution, ExecutionAction, ExitKind, ForceCloseIgnoredReason,
+    PortfolioState, RuntimeEvent, RuntimeStep, StrategyHandler,
 };
 use shared::{Candle, PositionSide};
 
@@ -54,6 +54,47 @@ impl<S: StrategyHandler> TradingRuntime<S> {
         events.push(RuntimeEvent::TradableTickStarted {
             candle: candle.clone(),
         });
+
+        if let Some(risk_exit) = self
+            .portfolio
+            .open_position
+            .as_ref()
+            .and_then(|position| evaluate_risk_exit(position, &candle))
+        {
+            events.push(RuntimeEvent::RiskExitTriggered {
+                risk_exit: risk_exit.clone(),
+            });
+            events.push(RuntimeEvent::ExecutionActionPlanned {
+                action: ExecutionAction::RiskExit {
+                    side: risk_exit.side,
+                    selected: risk_exit.selected,
+                    exit_price: risk_exit.exit_price,
+                },
+            });
+
+            let closed_position = match risk_exit.side {
+                PositionSide::Long => self
+                    .portfolio
+                    .close_long_at_price(&candle, risk_exit.exit_price)
+                    .expect("planned long risk exit should be executable"),
+                PositionSide::Short => self
+                    .portfolio
+                    .close_short_at_price(&candle, risk_exit.exit_price)
+                    .expect("planned short risk exit should be executable"),
+            };
+            events.push(RuntimeEvent::PositionClosed {
+                closed_position,
+                exit_kind: ExitKind::RiskExit {
+                    selected: risk_exit.selected,
+                },
+            });
+            events.push(RuntimeEvent::PortfolioUpdated {
+                snapshot: self.portfolio.snapshot(candle.close),
+            });
+            events.push(RuntimeEvent::TradableTickCompleted);
+
+            return RuntimeStep::new(events, self.portfolio.snapshot(candle.close));
+        }
 
         let portfolio_before_decision = self.portfolio.snapshot(candle.close);
         let decision = self
@@ -140,7 +181,9 @@ impl<S: StrategyHandler> TradingRuntime<S> {
                     snapshot: self.portfolio.snapshot(candle.close),
                 });
             }
-            ExecutionAction::Noop | ExecutionAction::ForceClose => {}
+            ExecutionAction::Noop
+            | ExecutionAction::RiskExit { .. }
+            | ExecutionAction::ForceClose => {}
         }
 
         events.push(RuntimeEvent::TradableTickCompleted);

--- a/trading-runtime/src/runtime.rs
+++ b/trading-runtime/src/runtime.rs
@@ -68,7 +68,7 @@ impl<S: StrategyHandler> TradingRuntime<S> {
             .open_position
             .as_ref()
             .map(|position| position.side);
-        let planned = plan_execution(&decision, current_side);
+        let planned = plan_execution(&decision, current_side, candle.close);
         events.push(RuntimeEvent::ExecutionActionPlanned {
             action: planned.action.clone(),
         });

--- a/trading-runtime/src/runtime.rs
+++ b/trading-runtime/src/runtime.rs
@@ -10,46 +10,46 @@ use shared::{Candle, PositionSide};
 #[derive(Debug, Clone)]
 pub struct TradingRuntime<S> {
     portfolio: PortfolioState,
-    primary_candle_count: usize,
-    effective_warmup_bars: usize,
+    warmup_input_count: usize,
+    warmup_requirement: usize,
     strategy_handler: S,
 }
 
 impl<S: StrategyHandler> TradingRuntime<S> {
-    pub fn new(
-        portfolio: PortfolioState,
-        effective_warmup_bars: usize,
-        strategy_handler: S,
-    ) -> Self {
+    pub fn new(portfolio: PortfolioState, warmup_requirement: usize, strategy_handler: S) -> Self {
         Self {
             portfolio,
-            primary_candle_count: 0,
-            effective_warmup_bars,
+            warmup_input_count: 0,
+            warmup_requirement,
             strategy_handler,
         }
     }
 
-    pub fn on_primary_candle(&mut self, candle: Candle) -> RuntimeStep {
-        self.primary_candle_count += 1;
+    pub fn on_warmup_input(&mut self, candle: Candle) -> RuntimeStep {
+        self.warmup_input_count += 1;
 
-        let mut events = vec![RuntimeEvent::MarketInputAccepted {
+        let mut events = vec![RuntimeEvent::WarmupInputAccepted {
             candle: candle.clone(),
         }];
 
-        if self.primary_candle_count <= self.effective_warmup_bars {
-            events.push(RuntimeEvent::WarmupAdvanced {
-                current_primary_candle_count: self.primary_candle_count,
-                required_warmup_candles: self.effective_warmup_bars,
+        events.push(RuntimeEvent::WarmupAdvanced {
+            current_warmup_input_count: self.warmup_input_count,
+            required_warmup_inputs: self.warmup_requirement,
+        });
+
+        if self.warmup_input_count == self.warmup_requirement {
+            events.push(RuntimeEvent::WarmupCompleted {
+                completed_warmup_input_count: self.warmup_input_count,
             });
-
-            if self.primary_candle_count == self.effective_warmup_bars {
-                events.push(RuntimeEvent::WarmupCompleted {
-                    completed_primary_candle_count: self.primary_candle_count,
-                });
-            }
-
-            return RuntimeStep::new(events, self.portfolio.snapshot(candle.close));
         }
+
+        RuntimeStep::new(events, self.portfolio.snapshot(candle.close))
+    }
+
+    pub fn on_tradable_candle(&mut self, candle: Candle) -> RuntimeStep {
+        let mut events = vec![RuntimeEvent::MarketInputAccepted {
+            candle: candle.clone(),
+        }];
 
         events.push(RuntimeEvent::TradableTickStarted {
             candle: candle.clone(),
@@ -198,7 +198,7 @@ impl<S: StrategyHandler> TradingRuntime<S> {
         RuntimeStep::new(events, self.portfolio.snapshot(mark_candle.close))
     }
 
-    pub fn effective_warmup_bars(&self) -> usize {
-        self.effective_warmup_bars
+    pub fn warmup_requirement(&self) -> usize {
+        self.warmup_requirement
     }
 }

--- a/trading-runtime/src/runtime.rs
+++ b/trading-runtime/src/runtime.rs
@@ -1,8 +1,8 @@
 //! Trading runtime entrypoints.
 
 use crate::{
-    plan_execution, ExecutionAction, ForceCloseIgnoredReason, PortfolioState, RuntimeEvent,
-    RuntimeStep, StrategyHandler,
+    plan_execution, ExecutionAction, ExitKind, ForceCloseIgnoredReason, PortfolioState,
+    RuntimeEvent, RuntimeStep, StrategyHandler,
 };
 use shared::{Candle, PositionSide};
 
@@ -101,7 +101,10 @@ impl<S: StrategyHandler> TradingRuntime<S> {
                     .portfolio
                     .close_long(&candle)
                     .expect("planned close long should be executable");
-                events.push(RuntimeEvent::PositionClosed { closed_position });
+                events.push(RuntimeEvent::PositionClosed {
+                    closed_position,
+                    exit_kind: ExitKind::StrategyExit,
+                });
                 events.push(RuntimeEvent::PortfolioUpdated {
                     snapshot: self.portfolio.snapshot(candle.close),
                 });
@@ -129,7 +132,10 @@ impl<S: StrategyHandler> TradingRuntime<S> {
                     .portfolio
                     .close_short(&candle)
                     .expect("planned close short should be executable");
-                events.push(RuntimeEvent::PositionClosed { closed_position });
+                events.push(RuntimeEvent::PositionClosed {
+                    closed_position,
+                    exit_kind: ExitKind::StrategyExit,
+                });
                 events.push(RuntimeEvent::PortfolioUpdated {
                     snapshot: self.portfolio.snapshot(candle.close),
                 });
@@ -171,7 +177,10 @@ impl<S: StrategyHandler> TradingRuntime<S> {
             events.push(RuntimeEvent::ExecutionActionPlanned {
                 action: ExecutionAction::ForceClose,
             });
-            events.push(RuntimeEvent::PositionClosed { closed_position });
+            events.push(RuntimeEvent::PositionClosed {
+                closed_position,
+                exit_kind: ExitKind::ForceClose,
+            });
             events.push(RuntimeEvent::PortfolioUpdated {
                 snapshot: self.portfolio.snapshot(mark_candle.close),
             });

--- a/trading-runtime/tests/risk_exit.rs
+++ b/trading-runtime/tests/risk_exit.rs
@@ -1,0 +1,273 @@
+use shared::{Candle, Position, PositionSide};
+use trading_runtime::{evaluate_risk_exit, RiskExitKind, RiskExitTriggered};
+
+fn position(side: PositionSide, stop_loss: Option<f64>, take_profit: Option<f64>) -> Position {
+    Position {
+        symbol: "BTC-USD".into(),
+        side,
+        entry_price: 100.0,
+        size: 2.0,
+        entry_time: 1,
+        stop_loss,
+        take_profit,
+    }
+}
+
+fn candle(open: f64, high: f64, low: f64, close: f64) -> Candle {
+    Candle {
+        timestamp: 2,
+        symbol: "BTC-USD".into(),
+        open,
+        high,
+        low,
+        close,
+        volume: 1_000.0,
+        timeframe: "1m".into(),
+    }
+}
+
+fn expected(
+    side: PositionSide,
+    selected: RiskExitKind,
+    triggered: Vec<RiskExitKind>,
+    exit_price: f64,
+) -> Option<RiskExitTriggered> {
+    Some(RiskExitTriggered {
+        side,
+        selected,
+        triggered,
+        exit_price,
+    })
+}
+
+#[test]
+fn position_without_entry_risk_never_produces_risk_exit() {
+    let open_position = position(PositionSide::Long, None, None);
+
+    let result = evaluate_risk_exit(&open_position, &candle(50.0, 150.0, 40.0, 120.0));
+
+    assert_eq!(result, None);
+    assert_eq!(open_position, position(PositionSide::Long, None, None));
+}
+
+#[test]
+fn long_stop_loss_exits_at_open_gap_or_stop_loss_price() {
+    assert_eq!(
+        evaluate_risk_exit(
+            &position(PositionSide::Long, Some(90.0), None),
+            &candle(89.0, 100.0, 80.0, 95.0),
+        ),
+        expected(
+            PositionSide::Long,
+            RiskExitKind::StopLoss,
+            vec![RiskExitKind::StopLoss],
+            89.0,
+        ),
+    );
+
+    assert_eq!(
+        evaluate_risk_exit(
+            &position(PositionSide::Long, Some(90.0), None),
+            &candle(100.0, 105.0, 90.0, 95.0),
+        ),
+        expected(
+            PositionSide::Long,
+            RiskExitKind::StopLoss,
+            vec![RiskExitKind::StopLoss],
+            90.0,
+        ),
+    );
+}
+
+#[test]
+fn stop_loss_open_gap_equality_exits_at_open_price() {
+    assert_eq!(
+        evaluate_risk_exit(
+            &position(PositionSide::Long, Some(90.0), None),
+            &candle(90.0, 100.0, 85.0, 95.0),
+        ),
+        expected(
+            PositionSide::Long,
+            RiskExitKind::StopLoss,
+            vec![RiskExitKind::StopLoss],
+            90.0,
+        ),
+    );
+
+    assert_eq!(
+        evaluate_risk_exit(
+            &position(PositionSide::Short, Some(110.0), None),
+            &candle(110.0, 115.0, 100.0, 105.0),
+        ),
+        expected(
+            PositionSide::Short,
+            RiskExitKind::StopLoss,
+            vec![RiskExitKind::StopLoss],
+            110.0,
+        ),
+    );
+}
+
+#[test]
+fn long_take_profit_exits_at_open_gap_or_take_profit_price() {
+    assert_eq!(
+        evaluate_risk_exit(
+            &position(PositionSide::Long, None, Some(120.0)),
+            &candle(120.0, 125.0, 110.0, 121.0),
+        ),
+        expected(
+            PositionSide::Long,
+            RiskExitKind::TakeProfit,
+            vec![RiskExitKind::TakeProfit],
+            120.0,
+        ),
+    );
+
+    assert_eq!(
+        evaluate_risk_exit(
+            &position(PositionSide::Long, None, Some(120.0)),
+            &candle(100.0, 120.0, 95.0, 115.0),
+        ),
+        expected(
+            PositionSide::Long,
+            RiskExitKind::TakeProfit,
+            vec![RiskExitKind::TakeProfit],
+            120.0,
+        ),
+    );
+}
+
+#[test]
+fn short_stop_loss_exits_at_open_gap_or_stop_loss_price() {
+    assert_eq!(
+        evaluate_risk_exit(
+            &position(PositionSide::Short, Some(110.0), None),
+            &candle(111.0, 120.0, 100.0, 112.0),
+        ),
+        expected(
+            PositionSide::Short,
+            RiskExitKind::StopLoss,
+            vec![RiskExitKind::StopLoss],
+            111.0,
+        ),
+    );
+
+    assert_eq!(
+        evaluate_risk_exit(
+            &position(PositionSide::Short, Some(110.0), None),
+            &candle(100.0, 110.0, 95.0, 105.0),
+        ),
+        expected(
+            PositionSide::Short,
+            RiskExitKind::StopLoss,
+            vec![RiskExitKind::StopLoss],
+            110.0,
+        ),
+    );
+}
+
+#[test]
+fn short_take_profit_exits_at_open_gap_or_take_profit_price() {
+    assert_eq!(
+        evaluate_risk_exit(
+            &position(PositionSide::Short, None, Some(80.0)),
+            &candle(80.0, 90.0, 75.0, 79.0),
+        ),
+        expected(
+            PositionSide::Short,
+            RiskExitKind::TakeProfit,
+            vec![RiskExitKind::TakeProfit],
+            80.0,
+        ),
+    );
+
+    assert_eq!(
+        evaluate_risk_exit(
+            &position(PositionSide::Short, None, Some(80.0)),
+            &candle(100.0, 105.0, 80.0, 85.0),
+        ),
+        expected(
+            PositionSide::Short,
+            RiskExitKind::TakeProfit,
+            vec![RiskExitKind::TakeProfit],
+            80.0,
+        ),
+    );
+}
+
+#[test]
+fn intrabar_touching_stop_loss_and_take_profit_selects_stop_loss_and_reports_both() {
+    assert_eq!(
+        evaluate_risk_exit(
+            &position(PositionSide::Long, Some(90.0), Some(120.0)),
+            &candle(100.0, 120.0, 90.0, 105.0),
+        ),
+        expected(
+            PositionSide::Long,
+            RiskExitKind::StopLoss,
+            vec![RiskExitKind::StopLoss, RiskExitKind::TakeProfit],
+            90.0,
+        ),
+    );
+
+    assert_eq!(
+        evaluate_risk_exit(
+            &position(PositionSide::Short, Some(110.0), Some(80.0)),
+            &candle(100.0, 110.0, 80.0, 95.0),
+        ),
+        expected(
+            PositionSide::Short,
+            RiskExitKind::StopLoss,
+            vec![RiskExitKind::StopLoss, RiskExitKind::TakeProfit],
+            110.0,
+        ),
+    );
+}
+
+#[test]
+fn open_gap_trigger_wins_before_intrabar_boundaries() {
+    assert_eq!(
+        evaluate_risk_exit(
+            &position(PositionSide::Long, Some(90.0), Some(120.0)),
+            &candle(121.0, 130.0, 80.0, 100.0),
+        ),
+        expected(
+            PositionSide::Long,
+            RiskExitKind::TakeProfit,
+            vec![RiskExitKind::TakeProfit],
+            121.0,
+        ),
+    );
+
+    assert_eq!(
+        evaluate_risk_exit(
+            &position(PositionSide::Short, Some(110.0), Some(80.0)),
+            &candle(79.0, 120.0, 70.0, 100.0),
+        ),
+        expected(
+            PositionSide::Short,
+            RiskExitKind::TakeProfit,
+            vec![RiskExitKind::TakeProfit],
+            79.0,
+        ),
+    );
+}
+
+#[test]
+fn configured_boundaries_that_are_not_touched_do_not_produce_risk_exit() {
+    assert_eq!(
+        evaluate_risk_exit(
+            &position(PositionSide::Long, Some(90.0), Some(120.0)),
+            &candle(100.0, 119.0, 91.0, 105.0),
+        ),
+        None,
+    );
+
+    assert_eq!(
+        evaluate_risk_exit(
+            &position(PositionSide::Short, Some(110.0), Some(80.0)),
+            &candle(100.0, 109.0, 81.0, 95.0),
+        ),
+        None,
+    );
+}

--- a/trading-runtime/tests/risk_exit_regressions.rs
+++ b/trading-runtime/tests/risk_exit_regressions.rs
@@ -1,0 +1,318 @@
+use shared::{Candle, Position, PositionSide};
+use std::{cell::RefCell, rc::Rc};
+use trading_runtime::{
+    ClosedPosition, ExecutionAction, ExitKind, PortfolioState, RiskExitKind, RiskExitTriggered,
+    RuntimeEvent, RuntimePortfolioSnapshot, RuntimeStep, StrategyDecision, StrategyHandler,
+    TradingRuntime,
+};
+
+fn ohlc_candle(timestamp: i64, open: f64, high: f64, low: f64, close: f64) -> Candle {
+    Candle {
+        timestamp,
+        symbol: "BTC-USD".into(),
+        open,
+        high,
+        low,
+        close,
+        volume: 1_000.0,
+        timeframe: "1m".into(),
+    }
+}
+
+fn position_with_entry_risk(
+    side: PositionSide,
+    entry_price: f64,
+    stop_loss: Option<f64>,
+    take_profit: Option<f64>,
+) -> Position {
+    Position {
+        symbol: "BTC-USD".into(),
+        side,
+        entry_price,
+        size: 2.0,
+        entry_time: 1,
+        stop_loss,
+        take_profit,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CountingStrategyHandler {
+    calls: Rc<RefCell<usize>>,
+}
+
+impl StrategyHandler for CountingStrategyHandler {
+    fn next_decision(
+        &mut self,
+        _candle: &Candle,
+        _portfolio: &RuntimePortfolioSnapshot,
+    ) -> StrategyDecision {
+        *self.calls.borrow_mut() += 1;
+        StrategyDecision::hold()
+    }
+}
+
+fn runtime_with_open_position(
+    open_position: Position,
+    warmup_requirement: usize,
+) -> (TradingRuntime<CountingStrategyHandler>, Rc<RefCell<usize>>) {
+    let mut portfolio = PortfolioState::new(1_000.0);
+    portfolio.open_position = Some(open_position);
+    let strategy_calls = Rc::new(RefCell::new(0));
+    let runtime = TradingRuntime::new(
+        portfolio,
+        warmup_requirement,
+        CountingStrategyHandler {
+            calls: Rc::clone(&strategy_calls),
+        },
+    );
+
+    (runtime, strategy_calls)
+}
+
+fn risk_exit_event(step: &RuntimeStep) -> &RiskExitTriggered {
+    step.events
+        .iter()
+        .find_map(|event| match event {
+            RuntimeEvent::RiskExitTriggered { risk_exit } => Some(risk_exit),
+            _ => None,
+        })
+        .expect("risk exit event should be emitted")
+}
+
+fn closed_position_event(step: &RuntimeStep) -> (&ClosedPosition, ExitKind) {
+    step.events
+        .iter()
+        .find_map(|event| match event {
+            RuntimeEvent::PositionClosed {
+                closed_position,
+                exit_kind,
+            } => Some((closed_position, *exit_kind)),
+            _ => None,
+        })
+        .expect("position closed event should be emitted")
+}
+
+fn execution_action_event(step: &RuntimeStep) -> &ExecutionAction {
+    step.events
+        .iter()
+        .find_map(|event| match event {
+            RuntimeEvent::ExecutionActionPlanned { action } => Some(action),
+            _ => None,
+        })
+        .expect("execution action should be planned")
+}
+
+fn assert_no_strategy_tick_events(step: &RuntimeStep) {
+    assert!(step.events.iter().all(|event| !matches!(
+        event,
+        RuntimeEvent::StrategyDecisionProduced { .. }
+            | RuntimeEvent::StrategyDecisionIgnored { .. }
+    )));
+}
+
+#[test]
+fn regression_long_stop_loss_uses_stop_price_not_legacy_candle_close() {
+    let open_position = position_with_entry_risk(PositionSide::Long, 100.0, Some(90.0), None);
+    let exit_candle = ohlc_candle(2, 100.0, 105.0, 90.0, 88.0);
+    let (mut runtime, strategy_calls) = runtime_with_open_position(open_position.clone(), 0);
+
+    let step = runtime.on_tradable_candle(exit_candle.clone());
+
+    assert_eq!(
+        risk_exit_event(&step),
+        &RiskExitTriggered {
+            side: PositionSide::Long,
+            selected: RiskExitKind::StopLoss,
+            triggered: vec![RiskExitKind::StopLoss],
+            exit_price: 90.0,
+        }
+    );
+    assert_eq!(
+        execution_action_event(&step),
+        &ExecutionAction::RiskExit {
+            side: PositionSide::Long,
+            selected: RiskExitKind::StopLoss,
+            exit_price: 90.0,
+        }
+    );
+    let (closed_position, exit_kind) = closed_position_event(&step);
+    assert_eq!(closed_position.position, open_position);
+    assert_eq!(closed_position.exit_price, 90.0);
+    assert_ne!(closed_position.exit_price, exit_candle.close);
+    assert_eq!(closed_position.realized_pnl, -20.0);
+    assert_eq!(
+        exit_kind,
+        ExitKind::RiskExit {
+            selected: RiskExitKind::StopLoss
+        }
+    );
+    assert_eq!(step.portfolio_snapshot.realized_cash_balance, 980.0);
+    assert_eq!(step.portfolio_snapshot.completed_trade_count, 1);
+    assert!(step.portfolio_snapshot.open_position.is_none());
+    assert_no_strategy_tick_events(&step);
+    assert_eq!(*strategy_calls.borrow(), 0);
+}
+
+#[test]
+fn regression_short_stop_loss_uses_stop_price_not_legacy_candle_close() {
+    let open_position = position_with_entry_risk(PositionSide::Short, 100.0, Some(110.0), None);
+    let exit_candle = ohlc_candle(2, 100.0, 110.0, 95.0, 115.0);
+    let (mut runtime, strategy_calls) = runtime_with_open_position(open_position.clone(), 0);
+
+    let step = runtime.on_tradable_candle(exit_candle.clone());
+
+    assert_eq!(
+        risk_exit_event(&step),
+        &RiskExitTriggered {
+            side: PositionSide::Short,
+            selected: RiskExitKind::StopLoss,
+            triggered: vec![RiskExitKind::StopLoss],
+            exit_price: 110.0,
+        }
+    );
+    let (closed_position, exit_kind) = closed_position_event(&step);
+    assert_eq!(closed_position.position, open_position);
+    assert_eq!(closed_position.exit_price, 110.0);
+    assert_ne!(closed_position.exit_price, exit_candle.close);
+    assert_eq!(closed_position.realized_pnl, -20.0);
+    assert_eq!(
+        exit_kind,
+        ExitKind::RiskExit {
+            selected: RiskExitKind::StopLoss
+        }
+    );
+    assert_eq!(step.portfolio_snapshot.realized_cash_balance, 980.0);
+    assert_eq!(step.portfolio_snapshot.completed_trade_count, 1);
+    assert!(step.portfolio_snapshot.open_position.is_none());
+    assert_no_strategy_tick_events(&step);
+    assert_eq!(*strategy_calls.borrow(), 0);
+}
+
+#[test]
+fn regression_take_profit_uses_target_price_not_legacy_candle_close() {
+    let open_position = position_with_entry_risk(PositionSide::Long, 100.0, None, Some(120.0));
+    let exit_candle = ohlc_candle(2, 100.0, 120.0, 95.0, 112.0);
+    let (mut runtime, strategy_calls) = runtime_with_open_position(open_position, 0);
+
+    let step = runtime.on_tradable_candle(exit_candle.clone());
+
+    assert_eq!(
+        risk_exit_event(&step),
+        &RiskExitTriggered {
+            side: PositionSide::Long,
+            selected: RiskExitKind::TakeProfit,
+            triggered: vec![RiskExitKind::TakeProfit],
+            exit_price: 120.0,
+        }
+    );
+    let (closed_position, exit_kind) = closed_position_event(&step);
+    assert_eq!(closed_position.exit_price, 120.0);
+    assert_ne!(closed_position.exit_price, exit_candle.close);
+    assert_eq!(closed_position.realized_pnl, 40.0);
+    assert_eq!(
+        exit_kind,
+        ExitKind::RiskExit {
+            selected: RiskExitKind::TakeProfit
+        }
+    );
+    assert_eq!(step.portfolio_snapshot.realized_cash_balance, 1_040.0);
+    assert_no_strategy_tick_events(&step);
+    assert_eq!(*strategy_calls.borrow(), 0);
+}
+
+#[test]
+fn regression_both_intrabar_boundaries_select_stop_loss_and_expose_both_triggered_kinds() {
+    let open_position =
+        position_with_entry_risk(PositionSide::Long, 100.0, Some(90.0), Some(120.0));
+    let exit_candle = ohlc_candle(2, 100.0, 120.0, 90.0, 110.0);
+    let (mut runtime, strategy_calls) = runtime_with_open_position(open_position, 0);
+
+    let step = runtime.on_tradable_candle(exit_candle);
+
+    assert_eq!(
+        risk_exit_event(&step),
+        &RiskExitTriggered {
+            side: PositionSide::Long,
+            selected: RiskExitKind::StopLoss,
+            triggered: vec![RiskExitKind::StopLoss, RiskExitKind::TakeProfit],
+            exit_price: 90.0,
+        }
+    );
+    let (closed_position, exit_kind) = closed_position_event(&step);
+    assert_eq!(closed_position.exit_price, 90.0);
+    assert_eq!(
+        exit_kind,
+        ExitKind::RiskExit {
+            selected: RiskExitKind::StopLoss
+        }
+    );
+    assert_no_strategy_tick_events(&step);
+    assert_eq!(*strategy_calls.borrow(), 0);
+}
+
+#[test]
+fn regression_warmup_input_crossing_stop_loss_does_not_close_or_emit_risk_exit() {
+    let open_position = position_with_entry_risk(PositionSide::Long, 100.0, Some(90.0), None);
+    let warmup_candle = ohlc_candle(2, 100.0, 101.0, 80.0, 85.0);
+    let (mut runtime, strategy_calls) = runtime_with_open_position(open_position.clone(), 1);
+
+    let step = runtime.on_warmup_input(warmup_candle);
+
+    assert!(step
+        .events
+        .iter()
+        .any(|event| matches!(event, RuntimeEvent::WarmupInputAccepted { .. })));
+    assert!(step.events.iter().all(|event| !matches!(
+        event,
+        RuntimeEvent::RiskExitTriggered { .. }
+            | RuntimeEvent::ExecutionActionPlanned { .. }
+            | RuntimeEvent::PositionClosed { .. }
+            | RuntimeEvent::PortfolioUpdated { .. }
+            | RuntimeEvent::TradableTickStarted { .. }
+    )));
+    assert_eq!(step.portfolio_snapshot.open_position, Some(open_position));
+    assert_eq!(step.portfolio_snapshot.completed_trade_count, 0);
+    assert_eq!(step.portfolio_snapshot.realized_cash_balance, 1_000.0);
+    assert_eq!(*strategy_calls.borrow(), 0);
+}
+
+#[test]
+fn regression_first_tradable_candle_after_warmup_can_close_breached_stop_before_strategy_tick() {
+    let open_position = position_with_entry_risk(PositionSide::Long, 100.0, Some(90.0), None);
+    let warmup_candle = ohlc_candle(2, 100.0, 101.0, 95.0, 98.0);
+    let first_tradable_candle = ohlc_candle(3, 85.0, 88.0, 80.0, 84.0);
+    let (mut runtime, strategy_calls) = runtime_with_open_position(open_position, 1);
+
+    let warmup_step = runtime.on_warmup_input(warmup_candle);
+    let tradable_step = runtime.on_tradable_candle(first_tradable_candle.clone());
+
+    assert!(warmup_step.portfolio_snapshot.open_position.is_some());
+    assert_eq!(
+        risk_exit_event(&tradable_step),
+        &RiskExitTriggered {
+            side: PositionSide::Long,
+            selected: RiskExitKind::StopLoss,
+            triggered: vec![RiskExitKind::StopLoss],
+            exit_price: 85.0,
+        }
+    );
+    let (closed_position, exit_kind) = closed_position_event(&tradable_step);
+    assert_eq!(closed_position.exit_price, first_tradable_candle.open);
+    assert_ne!(closed_position.exit_price, first_tradable_candle.close);
+    assert_eq!(closed_position.realized_pnl, -30.0);
+    assert_eq!(
+        exit_kind,
+        ExitKind::RiskExit {
+            selected: RiskExitKind::StopLoss
+        }
+    );
+    assert_eq!(
+        tradable_step.portfolio_snapshot.realized_cash_balance,
+        970.0
+    );
+    assert_eq!(tradable_step.portfolio_snapshot.completed_trade_count, 1);
+    assert!(tradable_step.portfolio_snapshot.open_position.is_none());
+    assert_no_strategy_tick_events(&tradable_step);
+    assert_eq!(*strategy_calls.borrow(), 0);
+}

--- a/trading-runtime/tests/runtime_step.rs
+++ b/trading-runtime/tests/runtime_step.rs
@@ -1,4 +1,4 @@
-use trading_runtime::{RuntimeEvent, RuntimeStep, StrategyDecision};
+use trading_runtime::{ExitKind, RiskExitKind, RuntimeEvent, RuntimeStep, StrategyDecision};
 
 fn candle() -> shared::Candle {
     shared::Candle {
@@ -49,4 +49,24 @@ fn runtime_step_returns_ordered_events_and_current_portfolio_snapshot() {
         ]
     );
     assert_eq!(step.portfolio_snapshot, snapshot);
+}
+
+#[test]
+fn exit_kind_type_surface_represents_risk_exit_selection() {
+    assert_eq!(
+        ExitKind::RiskExit {
+            selected: RiskExitKind::StopLoss,
+        },
+        ExitKind::RiskExit {
+            selected: RiskExitKind::StopLoss,
+        }
+    );
+    assert_ne!(
+        ExitKind::RiskExit {
+            selected: RiskExitKind::StopLoss,
+        },
+        ExitKind::RiskExit {
+            selected: RiskExitKind::TakeProfit,
+        }
+    );
 }

--- a/trading-runtime/tests/trading_runtime.rs
+++ b/trading-runtime/tests/trading_runtime.rs
@@ -1,17 +1,23 @@
-use shared::{Position, PositionSide};
+use shared::{Candle, Position, PositionSide};
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 use trading_runtime::{
     ClosedPosition, ExecutionAction, ExitKind, ForceCloseIgnoredReason, IgnoredDecisionReason,
-    PortfolioState, PredeterminedStrategyHandler, RuntimeEvent, RuntimePortfolioSnapshot,
-    StrategyDecision, StrategyDecisionIntent, TradingRuntime,
+    PortfolioState, PredeterminedStrategyHandler, RiskExitKind, RiskExitTriggered, RuntimeEvent,
+    RuntimePortfolioSnapshot, StrategyDecision, StrategyDecisionIntent, StrategyHandler,
+    TradingRuntime,
 };
 
-fn candle(timestamp: i64, close: f64) -> shared::Candle {
-    shared::Candle {
+fn candle(timestamp: i64, close: f64) -> Candle {
+    ohlc_candle(timestamp, close, close, close, close)
+}
+
+fn ohlc_candle(timestamp: i64, open: f64, high: f64, low: f64, close: f64) -> Candle {
+    Candle {
         timestamp,
         symbol: "BTC-USD".into(),
-        open: close,
-        high: close,
-        low: close,
+        open,
+        high,
+        low,
         close,
         volume: 1_000.0,
         timeframe: "1m".into(),
@@ -43,7 +49,7 @@ fn position_with_entry_risk(
 
 fn assert_ignored_step(
     step: trading_runtime::RuntimeStep,
-    candle: shared::Candle,
+    candle: Candle,
     decision: StrategyDecision,
     reason: IgnoredDecisionReason,
     expected_snapshot: RuntimePortfolioSnapshot,
@@ -66,6 +72,193 @@ fn assert_ignored_step(
         ]
     );
     assert_eq!(step.portfolio_snapshot, expected_snapshot);
+}
+
+#[derive(Clone)]
+struct CountingStrategyHandler {
+    calls: Rc<RefCell<usize>>,
+    decisions: VecDeque<StrategyDecision>,
+}
+
+impl CountingStrategyHandler {
+    fn from_decisions(
+        calls: Rc<RefCell<usize>>,
+        decisions: impl IntoIterator<Item = StrategyDecision>,
+    ) -> Self {
+        Self {
+            calls,
+            decisions: decisions.into_iter().collect(),
+        }
+    }
+}
+
+impl StrategyHandler for CountingStrategyHandler {
+    fn next_decision(
+        &mut self,
+        _candle: &Candle,
+        _portfolio: &RuntimePortfolioSnapshot,
+    ) -> StrategyDecision {
+        *self.calls.borrow_mut() += 1;
+        self.decisions
+            .pop_front()
+            .unwrap_or_else(StrategyDecision::hold)
+    }
+}
+
+fn assert_risk_exit_step(
+    open_position: Position,
+    exit_candle: Candle,
+    risk_exit: RiskExitTriggered,
+    expected_realized_pnl: f64,
+    expected_realized_cash_balance: f64,
+) {
+    let expected_closed = ClosedPosition {
+        position: open_position.clone(),
+        exit_price: risk_exit.exit_price,
+        exit_time: exit_candle.timestamp,
+        realized_pnl: expected_realized_pnl,
+    };
+    let expected_snapshot = RuntimePortfolioSnapshot {
+        realized_cash_balance: expected_realized_cash_balance,
+        open_position: None,
+        completed_trade_count: 1,
+        current_equity: expected_realized_cash_balance,
+    };
+    let mut portfolio = PortfolioState::new(1_000.0);
+    portfolio.open_position = Some(open_position);
+    let strategy_calls = Rc::new(RefCell::new(0));
+    let mut runtime = TradingRuntime::new(
+        portfolio,
+        0,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&strategy_calls),
+            [
+                StrategyDecision::close_long(),
+                StrategyDecision::close_short(),
+            ],
+        ),
+    );
+
+    let step = runtime.on_tradable_candle(exit_candle.clone());
+
+    assert_eq!(
+        step.events,
+        vec![
+            RuntimeEvent::MarketInputAccepted {
+                candle: exit_candle.clone(),
+            },
+            RuntimeEvent::TradableTickStarted {
+                candle: exit_candle,
+            },
+            RuntimeEvent::RiskExitTriggered {
+                risk_exit: risk_exit.clone(),
+            },
+            RuntimeEvent::ExecutionActionPlanned {
+                action: ExecutionAction::RiskExit {
+                    side: risk_exit.side,
+                    selected: risk_exit.selected,
+                    exit_price: risk_exit.exit_price,
+                },
+            },
+            RuntimeEvent::PositionClosed {
+                closed_position: expected_closed,
+                exit_kind: ExitKind::RiskExit {
+                    selected: risk_exit.selected,
+                },
+            },
+            RuntimeEvent::PortfolioUpdated {
+                snapshot: expected_snapshot.clone(),
+            },
+            RuntimeEvent::TradableTickCompleted,
+        ]
+    );
+    assert_eq!(*strategy_calls.borrow(), 0);
+    assert_eq!(step.portfolio_snapshot, expected_snapshot);
+    assert!(step.portfolio_snapshot.open_position.is_none());
+    assert_eq!(
+        step.portfolio_snapshot.current_equity,
+        step.portfolio_snapshot.realized_cash_balance
+    );
+}
+
+#[test]
+fn tradable_candle_with_long_stop_loss_risk_exit_closes_before_strategy_tick() {
+    assert_risk_exit_step(
+        position_with_entry_risk(PositionSide::Long, 1, 100.0, 2.0, Some(90.0), None),
+        ohlc_candle(2, 100.0, 105.0, 90.0, 99.0),
+        RiskExitTriggered {
+            side: PositionSide::Long,
+            selected: RiskExitKind::StopLoss,
+            triggered: vec![RiskExitKind::StopLoss],
+            exit_price: 90.0,
+        },
+        -20.0,
+        980.0,
+    );
+}
+
+#[test]
+fn tradable_candle_with_long_take_profit_risk_exit_closes_at_selected_price() {
+    assert_risk_exit_step(
+        position_with_entry_risk(PositionSide::Long, 1, 100.0, 2.0, None, Some(120.0)),
+        ohlc_candle(2, 100.0, 120.0, 95.0, 110.0),
+        RiskExitTriggered {
+            side: PositionSide::Long,
+            selected: RiskExitKind::TakeProfit,
+            triggered: vec![RiskExitKind::TakeProfit],
+            exit_price: 120.0,
+        },
+        40.0,
+        1_040.0,
+    );
+}
+
+#[test]
+fn tradable_candle_with_short_stop_loss_risk_exit_closes_at_selected_price() {
+    assert_risk_exit_step(
+        position_with_entry_risk(PositionSide::Short, 1, 100.0, 2.0, Some(110.0), None),
+        ohlc_candle(2, 100.0, 110.0, 95.0, 105.0),
+        RiskExitTriggered {
+            side: PositionSide::Short,
+            selected: RiskExitKind::StopLoss,
+            triggered: vec![RiskExitKind::StopLoss],
+            exit_price: 110.0,
+        },
+        -20.0,
+        980.0,
+    );
+}
+
+#[test]
+fn tradable_candle_with_short_take_profit_risk_exit_closes_at_selected_price() {
+    assert_risk_exit_step(
+        position_with_entry_risk(PositionSide::Short, 1, 100.0, 2.0, None, Some(80.0)),
+        ohlc_candle(2, 100.0, 105.0, 80.0, 90.0),
+        RiskExitTriggered {
+            side: PositionSide::Short,
+            selected: RiskExitKind::TakeProfit,
+            triggered: vec![RiskExitKind::TakeProfit],
+            exit_price: 80.0,
+        },
+        40.0,
+        1_040.0,
+    );
+}
+
+#[test]
+fn tradable_candle_with_both_intrabar_boundaries_selects_stop_loss_and_reports_both() {
+    assert_risk_exit_step(
+        position_with_entry_risk(PositionSide::Long, 1, 100.0, 2.0, Some(90.0), Some(120.0)),
+        ohlc_candle(2, 100.0, 120.0, 90.0, 110.0),
+        RiskExitTriggered {
+            side: PositionSide::Long,
+            selected: RiskExitKind::StopLoss,
+            triggered: vec![RiskExitKind::StopLoss, RiskExitKind::TakeProfit],
+            exit_price: 90.0,
+        },
+        -20.0,
+        980.0,
+    );
 }
 
 #[test]
@@ -243,6 +436,7 @@ fn warmup_input_crossing_stop_loss_on_initial_open_position_does_not_trade() {
         event,
         RuntimeEvent::StrategyDecisionProduced { .. }
             | RuntimeEvent::ExecutionActionPlanned { .. }
+            | RuntimeEvent::RiskExitTriggered { .. }
             | RuntimeEvent::PositionClosed { .. }
             | RuntimeEvent::PortfolioUpdated { .. }
             | RuntimeEvent::TradableTickStarted { .. }

--- a/trading-runtime/tests/trading_runtime.rs
+++ b/trading-runtime/tests/trading_runtime.rs
@@ -19,14 +19,25 @@ fn candle(timestamp: i64, close: f64) -> shared::Candle {
 }
 
 fn position(side: PositionSide, entry_time: i64, entry_price: f64, size: f64) -> Position {
+    position_with_entry_risk(side, entry_time, entry_price, size, None, None)
+}
+
+fn position_with_entry_risk(
+    side: PositionSide,
+    entry_time: i64,
+    entry_price: f64,
+    size: f64,
+    stop_loss: Option<f64>,
+    take_profit: Option<f64>,
+) -> Position {
     Position {
         symbol: "BTC-USD".into(),
         side,
         entry_price,
         size,
         entry_time,
-        stop_loss: None,
-        take_profit: None,
+        stop_loss,
+        take_profit,
     }
 }
 
@@ -315,6 +326,213 @@ fn primary_candle_opens_short_from_flat_and_updates_portfolio_snapshot() {
             .as_ref()
             .map(|p| p.side),
         Some(PositionSide::Short)
+    );
+}
+
+#[test]
+fn primary_candle_opens_long_with_valid_entry_risk_boundaries() {
+    let candle = candle(1, 100.0);
+    let decision = StrategyDecision::open_long(2.0).with_entry_risk(Some(90.0), Some(120.0));
+    let mut runtime = TradingRuntime::new(
+        PortfolioState::new(1_000.0),
+        0,
+        PredeterminedStrategyHandler::from_decisions([decision.clone()]),
+    );
+    let expected_position = position_with_entry_risk(
+        PositionSide::Long,
+        candle.timestamp,
+        candle.close,
+        2.0,
+        Some(90.0),
+        Some(120.0),
+    );
+
+    let step = runtime.on_primary_candle(candle.clone());
+
+    assert!(step.events.contains(&RuntimeEvent::ExecutionActionPlanned {
+        action: ExecutionAction::OpenLong {
+            quantity: 2.0,
+            stop_loss: Some(90.0),
+            take_profit: Some(120.0),
+        },
+    }));
+    assert!(step.events.contains(&RuntimeEvent::PositionOpened {
+        position: expected_position.clone(),
+    }));
+    assert_eq!(
+        step.portfolio_snapshot.open_position,
+        Some(expected_position)
+    );
+}
+
+#[test]
+fn primary_candle_opens_short_with_valid_entry_risk_boundaries() {
+    let candle = candle(1, 100.0);
+    let decision = StrategyDecision::open_short(2.0).with_entry_risk(Some(110.0), Some(80.0));
+    let mut runtime = TradingRuntime::new(
+        PortfolioState::new(1_000.0),
+        0,
+        PredeterminedStrategyHandler::from_decisions([decision.clone()]),
+    );
+    let expected_position = position_with_entry_risk(
+        PositionSide::Short,
+        candle.timestamp,
+        candle.close,
+        2.0,
+        Some(110.0),
+        Some(80.0),
+    );
+
+    let step = runtime.on_primary_candle(candle.clone());
+
+    assert!(step.events.contains(&RuntimeEvent::ExecutionActionPlanned {
+        action: ExecutionAction::OpenShort {
+            quantity: 2.0,
+            stop_loss: Some(110.0),
+            take_profit: Some(80.0),
+        },
+    }));
+    assert!(step.events.contains(&RuntimeEvent::PositionOpened {
+        position: expected_position.clone(),
+    }));
+    assert_eq!(
+        step.portfolio_snapshot.open_position,
+        Some(expected_position)
+    );
+}
+
+#[test]
+fn primary_candle_opens_with_one_valid_entry_risk_boundary() {
+    for (decision, expected_side, expected_stop_loss, expected_take_profit) in [
+        (
+            StrategyDecision::open_long(2.0).with_entry_risk(Some(90.0), None),
+            PositionSide::Long,
+            Some(90.0),
+            None,
+        ),
+        (
+            StrategyDecision::open_short(2.0).with_entry_risk(None, Some(80.0)),
+            PositionSide::Short,
+            None,
+            Some(80.0),
+        ),
+    ] {
+        let candle = candle(1, 100.0);
+        let mut runtime = TradingRuntime::new(
+            PortfolioState::new(1_000.0),
+            0,
+            PredeterminedStrategyHandler::from_decisions([decision]),
+        );
+
+        let step = runtime.on_primary_candle(candle.clone());
+
+        assert_eq!(
+            step.portfolio_snapshot.open_position,
+            Some(position_with_entry_risk(
+                expected_side,
+                candle.timestamp,
+                candle.close,
+                2.0,
+                expected_stop_loss,
+                expected_take_profit,
+            ))
+        );
+    }
+}
+
+#[test]
+fn primary_candle_ignores_invalid_entry_risk_without_portfolio_transition() {
+    let invalid_decisions = [
+        StrategyDecision::open_long(2.0).with_entry_risk(Some(f64::INFINITY), None),
+        StrategyDecision::open_long(2.0).with_entry_risk(Some(0.0), None),
+        StrategyDecision::open_long(2.0).with_entry_risk(Some(-1.0), None),
+        StrategyDecision::open_long(2.0).with_entry_risk(Some(100.0), None),
+        StrategyDecision::open_long(2.0).with_entry_risk(Some(101.0), None),
+        StrategyDecision::open_long(2.0).with_entry_risk(None, Some(f64::INFINITY)),
+        StrategyDecision::open_long(2.0).with_entry_risk(None, Some(0.0)),
+        StrategyDecision::open_long(2.0).with_entry_risk(None, Some(-1.0)),
+        StrategyDecision::open_long(2.0).with_entry_risk(None, Some(100.0)),
+        StrategyDecision::open_long(2.0).with_entry_risk(None, Some(99.0)),
+        StrategyDecision::open_short(2.0).with_entry_risk(Some(f64::INFINITY), None),
+        StrategyDecision::open_short(2.0).with_entry_risk(Some(0.0), None),
+        StrategyDecision::open_short(2.0).with_entry_risk(Some(-1.0), None),
+        StrategyDecision::open_short(2.0).with_entry_risk(Some(100.0), None),
+        StrategyDecision::open_short(2.0).with_entry_risk(Some(99.0), None),
+        StrategyDecision::open_short(2.0).with_entry_risk(None, Some(f64::INFINITY)),
+        StrategyDecision::open_short(2.0).with_entry_risk(None, Some(0.0)),
+        StrategyDecision::open_short(2.0).with_entry_risk(None, Some(-1.0)),
+        StrategyDecision::open_short(2.0).with_entry_risk(None, Some(100.0)),
+        StrategyDecision::open_short(2.0).with_entry_risk(None, Some(101.0)),
+    ];
+
+    for decision in invalid_decisions {
+        let candle = candle(1, 100.0);
+        let mut runtime = TradingRuntime::new(
+            PortfolioState::new(1_000.0),
+            0,
+            PredeterminedStrategyHandler::from_decisions([decision.clone()]),
+        );
+
+        let step = runtime.on_primary_candle(candle.clone());
+
+        assert_ignored_step(
+            step,
+            candle.clone(),
+            decision,
+            IgnoredDecisionReason::InvalidEntryRisk,
+            PortfolioState::new(1_000.0).snapshot(candle.close),
+        );
+    }
+}
+
+#[test]
+fn invalid_quantity_wins_before_invalid_entry_risk_while_flat() {
+    let candle = candle(1, 100.0);
+    let decision = StrategyDecision::open_long(0.0).with_entry_risk(Some(100.0), Some(99.0));
+    let mut runtime = TradingRuntime::new(
+        PortfolioState::new(1_000.0),
+        0,
+        PredeterminedStrategyHandler::from_decisions([decision.clone()]),
+    );
+
+    let step = runtime.on_primary_candle(candle.clone());
+
+    assert_ignored_step(
+        step,
+        candle.clone(),
+        decision,
+        IgnoredDecisionReason::InvalidQuantity,
+        PortfolioState::new(1_000.0).snapshot(candle.close),
+    );
+}
+
+#[test]
+fn position_already_open_wins_before_invalid_quantity_or_entry_risk() {
+    let entry_candle = candle(1, 100.0);
+    let invalid_candle = candle(2, 105.0);
+    let decision = StrategyDecision::open_short(0.0).with_entry_risk(Some(0.0), Some(150.0));
+    let mut runtime = TradingRuntime::new(
+        PortfolioState::new(1_000.0),
+        0,
+        PredeterminedStrategyHandler::from_decisions([
+            StrategyDecision::open_long(2.0),
+            decision.clone(),
+        ]),
+    );
+    runtime.on_primary_candle(entry_candle.clone());
+    let mut expected_portfolio = PortfolioState::new(1_000.0);
+    expected_portfolio
+        .open_long_from_flat(&entry_candle, 2.0, None, None)
+        .unwrap();
+
+    let step = runtime.on_primary_candle(invalid_candle.clone());
+
+    assert_ignored_step(
+        step,
+        invalid_candle.clone(),
+        decision,
+        IgnoredDecisionReason::PositionAlreadyOpen,
+        expected_portfolio.snapshot(invalid_candle.close),
     );
 }
 

--- a/trading-runtime/tests/trading_runtime.rs
+++ b/trading-runtime/tests/trading_runtime.rs
@@ -69,7 +69,7 @@ fn assert_ignored_step(
 }
 
 #[test]
-fn primary_candle_with_no_warmup_and_hold_while_flat_emits_tradable_noop_step() {
+fn tradable_candle_with_no_warmup_and_hold_while_flat_emits_tradable_noop_step() {
     let candle = candle(1, 100.0);
     let mut runtime = TradingRuntime::new(
         PortfolioState::new(1_000.0),
@@ -77,7 +77,7 @@ fn primary_candle_with_no_warmup_and_hold_while_flat_emits_tradable_noop_step() 
         PredeterminedStrategyHandler::from_decisions([StrategyDecision::hold()]),
     );
 
-    let step = runtime.on_primary_candle(candle.clone());
+    let step = runtime.on_tradable_candle(candle.clone());
 
     assert_eq!(
         step.events,
@@ -104,7 +104,18 @@ fn primary_candle_with_no_warmup_and_hold_while_flat_emits_tradable_noop_step() 
 }
 
 #[test]
-fn positive_warmup_advances_market_progress_without_calling_strategy_until_complete() {
+fn runtime_exposes_warmup_requirement_for_runner_fetching() {
+    let runtime = TradingRuntime::new(
+        PortfolioState::new(1_000.0),
+        2,
+        PredeterminedStrategyHandler::from_decisions([StrategyDecision::hold()]),
+    );
+
+    assert_eq!(runtime.warmup_requirement(), 2);
+}
+
+#[test]
+fn warmup_input_advances_market_progress_without_calling_strategy_until_complete() {
     let first_warmup = candle(1, 100.0);
     let second_warmup = candle(2, 101.0);
     let first_tradable = candle(3, 102.0);
@@ -115,19 +126,19 @@ fn positive_warmup_advances_market_progress_without_calling_strategy_until_compl
         PredeterminedStrategyHandler::from_decisions([decision.clone()]),
     );
 
-    let first_step = runtime.on_primary_candle(first_warmup.clone());
-    let second_step = runtime.on_primary_candle(second_warmup.clone());
-    let tradable_step = runtime.on_primary_candle(first_tradable.clone());
+    let first_step = runtime.on_warmup_input(first_warmup.clone());
+    let second_step = runtime.on_warmup_input(second_warmup.clone());
+    let tradable_step = runtime.on_tradable_candle(first_tradable.clone());
 
     assert_eq!(
         first_step.events,
         vec![
-            RuntimeEvent::MarketInputAccepted {
+            RuntimeEvent::WarmupInputAccepted {
                 candle: first_warmup.clone(),
             },
             RuntimeEvent::WarmupAdvanced {
-                current_primary_candle_count: 1,
-                required_warmup_candles: 2,
+                current_warmup_input_count: 1,
+                required_warmup_inputs: 2,
             },
         ]
     );
@@ -138,15 +149,15 @@ fn positive_warmup_advances_market_progress_without_calling_strategy_until_compl
     assert_eq!(
         second_step.events,
         vec![
-            RuntimeEvent::MarketInputAccepted {
+            RuntimeEvent::WarmupInputAccepted {
                 candle: second_warmup.clone(),
             },
             RuntimeEvent::WarmupAdvanced {
-                current_primary_candle_count: 2,
-                required_warmup_candles: 2,
+                current_warmup_input_count: 2,
+                required_warmup_inputs: 2,
             },
             RuntimeEvent::WarmupCompleted {
-                completed_primary_candle_count: 2,
+                completed_warmup_input_count: 2,
             },
         ]
     );
@@ -197,7 +208,49 @@ fn positive_warmup_advances_market_progress_without_calling_strategy_until_compl
 }
 
 #[test]
-fn zero_warmup_makes_first_primary_candle_tradable_without_warmup_completed() {
+fn warmup_input_crossing_stop_loss_on_initial_open_position_does_not_trade() {
+    let warmup = candle(1, 80.0);
+    let open_position =
+        position_with_entry_risk(PositionSide::Long, 0, 100.0, 2.0, Some(90.0), None);
+    let mut portfolio = PortfolioState::new(1_000.0);
+    portfolio.open_position = Some(open_position.clone());
+    let mut runtime = TradingRuntime::new(
+        portfolio,
+        1,
+        PredeterminedStrategyHandler::from_decisions([StrategyDecision::close_long()]),
+    );
+
+    let step = runtime.on_warmup_input(warmup.clone());
+
+    assert_eq!(
+        step.events,
+        vec![
+            RuntimeEvent::WarmupInputAccepted {
+                candle: warmup.clone(),
+            },
+            RuntimeEvent::WarmupAdvanced {
+                current_warmup_input_count: 1,
+                required_warmup_inputs: 1,
+            },
+            RuntimeEvent::WarmupCompleted {
+                completed_warmup_input_count: 1,
+            },
+        ]
+    );
+    assert_eq!(step.portfolio_snapshot.open_position, Some(open_position));
+    assert_eq!(step.portfolio_snapshot.completed_trade_count, 0);
+    assert!(!step.events.iter().any(|event| matches!(
+        event,
+        RuntimeEvent::StrategyDecisionProduced { .. }
+            | RuntimeEvent::ExecutionActionPlanned { .. }
+            | RuntimeEvent::PositionClosed { .. }
+            | RuntimeEvent::PortfolioUpdated { .. }
+            | RuntimeEvent::TradableTickStarted { .. }
+    )));
+}
+
+#[test]
+fn zero_warmup_makes_first_tradable_candle_tradable_without_warmup_completed() {
     let candle = candle(1, 100.0);
     let mut runtime = TradingRuntime::new(
         PortfolioState::new(1_000.0),
@@ -205,7 +258,7 @@ fn zero_warmup_makes_first_primary_candle_tradable_without_warmup_completed() {
         PredeterminedStrategyHandler::from_decisions([StrategyDecision::hold()]),
     );
 
-    let step = runtime.on_primary_candle(candle);
+    let step = runtime.on_tradable_candle(candle);
 
     assert!(!step
         .events
@@ -218,7 +271,7 @@ fn zero_warmup_makes_first_primary_candle_tradable_without_warmup_completed() {
 }
 
 #[test]
-fn primary_candle_opens_long_from_flat_and_updates_portfolio_snapshot() {
+fn tradable_candle_opens_long_from_flat_and_updates_portfolio_snapshot() {
     let candle = candle(1, 100.0);
     let decision = StrategyDecision::open_long(2.0);
     let mut runtime = TradingRuntime::new(
@@ -233,7 +286,7 @@ fn primary_candle_opens_long_from_flat_and_updates_portfolio_snapshot() {
         .unwrap();
     let expected_snapshot = expected_portfolio.snapshot(candle.close);
 
-    let step = runtime.on_primary_candle(candle.clone());
+    let step = runtime.on_tradable_candle(candle.clone());
 
     assert_eq!(
         step.events,
@@ -274,7 +327,7 @@ fn primary_candle_opens_long_from_flat_and_updates_portfolio_snapshot() {
 }
 
 #[test]
-fn primary_candle_opens_short_from_flat_and_updates_portfolio_snapshot() {
+fn tradable_candle_opens_short_from_flat_and_updates_portfolio_snapshot() {
     let candle = candle(1, 100.0);
     let decision = StrategyDecision::open_short(2.0);
     let mut runtime = TradingRuntime::new(
@@ -289,7 +342,7 @@ fn primary_candle_opens_short_from_flat_and_updates_portfolio_snapshot() {
         .unwrap();
     let expected_snapshot = expected_portfolio.snapshot(candle.close);
 
-    let step = runtime.on_primary_candle(candle.clone());
+    let step = runtime.on_tradable_candle(candle.clone());
 
     assert_eq!(
         step.events,
@@ -330,7 +383,7 @@ fn primary_candle_opens_short_from_flat_and_updates_portfolio_snapshot() {
 }
 
 #[test]
-fn primary_candle_opens_long_with_valid_entry_risk_boundaries() {
+fn tradable_candle_opens_long_with_valid_entry_risk_boundaries() {
     let candle = candle(1, 100.0);
     let decision = StrategyDecision::open_long(2.0).with_entry_risk(Some(90.0), Some(120.0));
     let mut runtime = TradingRuntime::new(
@@ -347,7 +400,7 @@ fn primary_candle_opens_long_with_valid_entry_risk_boundaries() {
         Some(120.0),
     );
 
-    let step = runtime.on_primary_candle(candle.clone());
+    let step = runtime.on_tradable_candle(candle.clone());
 
     assert!(step.events.contains(&RuntimeEvent::ExecutionActionPlanned {
         action: ExecutionAction::OpenLong {
@@ -366,7 +419,7 @@ fn primary_candle_opens_long_with_valid_entry_risk_boundaries() {
 }
 
 #[test]
-fn primary_candle_opens_short_with_valid_entry_risk_boundaries() {
+fn tradable_candle_opens_short_with_valid_entry_risk_boundaries() {
     let candle = candle(1, 100.0);
     let decision = StrategyDecision::open_short(2.0).with_entry_risk(Some(110.0), Some(80.0));
     let mut runtime = TradingRuntime::new(
@@ -383,7 +436,7 @@ fn primary_candle_opens_short_with_valid_entry_risk_boundaries() {
         Some(80.0),
     );
 
-    let step = runtime.on_primary_candle(candle.clone());
+    let step = runtime.on_tradable_candle(candle.clone());
 
     assert!(step.events.contains(&RuntimeEvent::ExecutionActionPlanned {
         action: ExecutionAction::OpenShort {
@@ -402,7 +455,7 @@ fn primary_candle_opens_short_with_valid_entry_risk_boundaries() {
 }
 
 #[test]
-fn primary_candle_opens_with_one_valid_entry_risk_boundary() {
+fn tradable_candle_opens_with_one_valid_entry_risk_boundary() {
     for (decision, expected_side, expected_stop_loss, expected_take_profit) in [
         (
             StrategyDecision::open_long(2.0).with_entry_risk(Some(90.0), None),
@@ -424,7 +477,7 @@ fn primary_candle_opens_with_one_valid_entry_risk_boundary() {
             PredeterminedStrategyHandler::from_decisions([decision]),
         );
 
-        let step = runtime.on_primary_candle(candle.clone());
+        let step = runtime.on_tradable_candle(candle.clone());
 
         assert_eq!(
             step.portfolio_snapshot.open_position,
@@ -441,7 +494,7 @@ fn primary_candle_opens_with_one_valid_entry_risk_boundary() {
 }
 
 #[test]
-fn primary_candle_ignores_invalid_entry_risk_without_portfolio_transition() {
+fn tradable_candle_ignores_invalid_entry_risk_without_portfolio_transition() {
     let invalid_decisions = [
         StrategyDecision::open_long(2.0).with_entry_risk(Some(f64::INFINITY), None),
         StrategyDecision::open_long(2.0).with_entry_risk(Some(0.0), None),
@@ -473,7 +526,7 @@ fn primary_candle_ignores_invalid_entry_risk_without_portfolio_transition() {
             PredeterminedStrategyHandler::from_decisions([decision.clone()]),
         );
 
-        let step = runtime.on_primary_candle(candle.clone());
+        let step = runtime.on_tradable_candle(candle.clone());
 
         assert_ignored_step(
             step,
@@ -495,7 +548,7 @@ fn invalid_quantity_wins_before_invalid_entry_risk_while_flat() {
         PredeterminedStrategyHandler::from_decisions([decision.clone()]),
     );
 
-    let step = runtime.on_primary_candle(candle.clone());
+    let step = runtime.on_tradable_candle(candle.clone());
 
     assert_ignored_step(
         step,
@@ -519,13 +572,13 @@ fn position_already_open_wins_before_invalid_quantity_or_entry_risk() {
             decision.clone(),
         ]),
     );
-    runtime.on_primary_candle(entry_candle.clone());
+    runtime.on_tradable_candle(entry_candle.clone());
     let mut expected_portfolio = PortfolioState::new(1_000.0);
     expected_portfolio
         .open_long_from_flat(&entry_candle, 2.0, None, None)
         .unwrap();
 
-    let step = runtime.on_primary_candle(invalid_candle.clone());
+    let step = runtime.on_tradable_candle(invalid_candle.clone());
 
     assert_ignored_step(
         step,
@@ -537,7 +590,7 @@ fn position_already_open_wins_before_invalid_quantity_or_entry_risk() {
 }
 
 #[test]
-fn primary_candle_closes_long_position_and_realizes_pnl() {
+fn tradable_candle_closes_long_position_and_realizes_pnl() {
     let entry_candle = candle(1, 100.0);
     let exit_candle = candle(2, 115.0);
     let mut runtime = TradingRuntime::new(
@@ -548,7 +601,7 @@ fn primary_candle_closes_long_position_and_realizes_pnl() {
             StrategyDecision::close_long(),
         ]),
     );
-    runtime.on_primary_candle(entry_candle.clone());
+    runtime.on_tradable_candle(entry_candle.clone());
     let opened_position = position(
         PositionSide::Long,
         entry_candle.timestamp,
@@ -568,7 +621,7 @@ fn primary_candle_closes_long_position_and_realizes_pnl() {
     expected_portfolio.close_long(&exit_candle).unwrap();
     let expected_snapshot = expected_portfolio.snapshot(exit_candle.close);
 
-    let step = runtime.on_primary_candle(exit_candle.clone());
+    let step = runtime.on_tradable_candle(exit_candle.clone());
 
     assert_eq!(
         step.events,
@@ -602,7 +655,7 @@ fn primary_candle_closes_long_position_and_realizes_pnl() {
 }
 
 #[test]
-fn primary_candle_ignores_invalid_opening_quantities_without_portfolio_transition() {
+fn tradable_candle_ignores_invalid_opening_quantities_without_portfolio_transition() {
     for decision in [
         StrategyDecision::new(StrategyDecisionIntent::OpenLong),
         StrategyDecision::open_long(0.0),
@@ -616,7 +669,7 @@ fn primary_candle_ignores_invalid_opening_quantities_without_portfolio_transitio
             PredeterminedStrategyHandler::from_decisions([decision.clone()]),
         );
 
-        let step = runtime.on_primary_candle(candle.clone());
+        let step = runtime.on_tradable_candle(candle.clone());
 
         assert_ignored_step(
             step,
@@ -629,7 +682,7 @@ fn primary_candle_ignores_invalid_opening_quantities_without_portfolio_transitio
 }
 
 #[test]
-fn primary_candle_ignores_close_decision_while_flat_without_portfolio_transition() {
+fn tradable_candle_ignores_close_decision_while_flat_without_portfolio_transition() {
     let candle = candle(1, 100.0);
     let decision = StrategyDecision::close_long();
     let mut runtime = TradingRuntime::new(
@@ -638,7 +691,7 @@ fn primary_candle_ignores_close_decision_while_flat_without_portfolio_transition
         PredeterminedStrategyHandler::from_decisions([decision.clone()]),
     );
 
-    let step = runtime.on_primary_candle(candle.clone());
+    let step = runtime.on_tradable_candle(candle.clone());
 
     assert_ignored_step(
         step,
@@ -650,7 +703,7 @@ fn primary_candle_ignores_close_decision_while_flat_without_portfolio_transition
 }
 
 #[test]
-fn primary_candle_ignores_close_long_while_short_without_portfolio_transition() {
+fn tradable_candle_ignores_close_long_while_short_without_portfolio_transition() {
     let entry_candle = candle(1, 100.0);
     let invalid_candle = candle(2, 95.0);
     let decision = StrategyDecision::close_long();
@@ -662,13 +715,13 @@ fn primary_candle_ignores_close_long_while_short_without_portfolio_transition() 
             decision.clone(),
         ]),
     );
-    runtime.on_primary_candle(entry_candle.clone());
+    runtime.on_tradable_candle(entry_candle.clone());
     let mut expected_portfolio = PortfolioState::new(1_000.0);
     expected_portfolio
         .open_short_from_flat(&entry_candle, 2.0, None, None)
         .unwrap();
 
-    let step = runtime.on_primary_candle(invalid_candle.clone());
+    let step = runtime.on_tradable_candle(invalid_candle.clone());
 
     assert_ignored_step(
         step,
@@ -680,7 +733,7 @@ fn primary_candle_ignores_close_long_while_short_without_portfolio_transition() 
 }
 
 #[test]
-fn primary_candle_ignores_close_short_while_long_without_portfolio_transition() {
+fn tradable_candle_ignores_close_short_while_long_without_portfolio_transition() {
     let entry_candle = candle(1, 100.0);
     let invalid_candle = candle(2, 105.0);
     let decision = StrategyDecision::close_short();
@@ -692,13 +745,13 @@ fn primary_candle_ignores_close_short_while_long_without_portfolio_transition() 
             decision.clone(),
         ]),
     );
-    runtime.on_primary_candle(entry_candle.clone());
+    runtime.on_tradable_candle(entry_candle.clone());
     let mut expected_portfolio = PortfolioState::new(1_000.0);
     expected_portfolio
         .open_long_from_flat(&entry_candle, 2.0, None, None)
         .unwrap();
 
-    let step = runtime.on_primary_candle(invalid_candle.clone());
+    let step = runtime.on_tradable_candle(invalid_candle.clone());
 
     assert_ignored_step(
         step,
@@ -710,7 +763,7 @@ fn primary_candle_ignores_close_short_while_long_without_portfolio_transition() 
 }
 
 #[test]
-fn primary_candle_ignores_open_long_while_already_long_without_portfolio_transition() {
+fn tradable_candle_ignores_open_long_while_already_long_without_portfolio_transition() {
     let entry_candle = candle(1, 100.0);
     let invalid_candle = candle(2, 105.0);
     let decision = StrategyDecision::open_long(2.0);
@@ -722,13 +775,13 @@ fn primary_candle_ignores_open_long_while_already_long_without_portfolio_transit
             decision.clone(),
         ]),
     );
-    runtime.on_primary_candle(entry_candle.clone());
+    runtime.on_tradable_candle(entry_candle.clone());
     let mut expected_portfolio = PortfolioState::new(1_000.0);
     expected_portfolio
         .open_long_from_flat(&entry_candle, 2.0, None, None)
         .unwrap();
 
-    let step = runtime.on_primary_candle(invalid_candle.clone());
+    let step = runtime.on_tradable_candle(invalid_candle.clone());
 
     assert_ignored_step(
         step,
@@ -740,7 +793,7 @@ fn primary_candle_ignores_open_long_while_already_long_without_portfolio_transit
 }
 
 #[test]
-fn primary_candle_ignores_open_short_while_already_short_without_portfolio_transition() {
+fn tradable_candle_ignores_open_short_while_already_short_without_portfolio_transition() {
     let entry_candle = candle(1, 100.0);
     let invalid_candle = candle(2, 95.0);
     let decision = StrategyDecision::open_short(2.0);
@@ -752,13 +805,13 @@ fn primary_candle_ignores_open_short_while_already_short_without_portfolio_trans
             decision.clone(),
         ]),
     );
-    runtime.on_primary_candle(entry_candle.clone());
+    runtime.on_tradable_candle(entry_candle.clone());
     let mut expected_portfolio = PortfolioState::new(1_000.0);
     expected_portfolio
         .open_short_from_flat(&entry_candle, 2.0, None, None)
         .unwrap();
 
-    let step = runtime.on_primary_candle(invalid_candle.clone());
+    let step = runtime.on_tradable_candle(invalid_candle.clone());
 
     assert_ignored_step(
         step,
@@ -770,7 +823,7 @@ fn primary_candle_ignores_open_short_while_already_short_without_portfolio_trans
 }
 
 #[test]
-fn primary_candle_closes_short_position_and_realizes_pnl() {
+fn tradable_candle_closes_short_position_and_realizes_pnl() {
     let entry_candle = candle(1, 100.0);
     let exit_candle = candle(2, 85.0);
     let mut runtime = TradingRuntime::new(
@@ -781,7 +834,7 @@ fn primary_candle_closes_short_position_and_realizes_pnl() {
             StrategyDecision::close_short(),
         ]),
     );
-    runtime.on_primary_candle(entry_candle.clone());
+    runtime.on_tradable_candle(entry_candle.clone());
     let opened_position = position(
         PositionSide::Short,
         entry_candle.timestamp,
@@ -801,7 +854,7 @@ fn primary_candle_closes_short_position_and_realizes_pnl() {
     expected_portfolio.close_short(&exit_candle).unwrap();
     let expected_snapshot = expected_portfolio.snapshot(exit_candle.close);
 
-    let step = runtime.on_primary_candle(exit_candle.clone());
+    let step = runtime.on_tradable_candle(exit_candle.clone());
 
     assert_eq!(
         step.events,
@@ -844,7 +897,7 @@ fn force_close_closes_open_long_position_with_ordered_events() {
         0,
         PredeterminedStrategyHandler::from_decisions([StrategyDecision::open_long(2.0)]),
     );
-    runtime.on_primary_candle(entry_candle.clone());
+    runtime.on_tradable_candle(entry_candle.clone());
     let opened_position = position(
         PositionSide::Long,
         entry_candle.timestamp,
@@ -902,7 +955,7 @@ fn force_close_closes_open_short_position_with_ordered_events() {
         0,
         PredeterminedStrategyHandler::from_decisions([StrategyDecision::open_short(2.0)]),
     );
-    runtime.on_primary_candle(entry_candle.clone());
+    runtime.on_tradable_candle(entry_candle.clone());
     let opened_position = position(
         PositionSide::Short,
         entry_candle.timestamp,
@@ -997,7 +1050,7 @@ fn force_close_works_while_runtime_is_still_in_warmup() {
         3,
         PredeterminedStrategyHandler::from_decisions([StrategyDecision::close_long()]),
     );
-    let warmup_step = runtime.on_primary_candle(warmup_candle.clone());
+    let warmup_step = runtime.on_warmup_input(warmup_candle.clone());
     let expected_closed = ClosedPosition {
         position: position(
             PositionSide::Long,
@@ -1021,12 +1074,12 @@ fn force_close_works_while_runtime_is_still_in_warmup() {
     assert_eq!(
         warmup_step.events,
         vec![
-            RuntimeEvent::MarketInputAccepted {
+            RuntimeEvent::WarmupInputAccepted {
                 candle: warmup_candle.clone(),
             },
             RuntimeEvent::WarmupAdvanced {
-                current_primary_candle_count: 1,
-                required_warmup_candles: 3,
+                current_warmup_input_count: 1,
+                required_warmup_inputs: 3,
             },
         ]
     );

--- a/trading-runtime/tests/trading_runtime.rs
+++ b/trading-runtime/tests/trading_runtime.rs
@@ -1,6 +1,6 @@
 use shared::{Position, PositionSide};
 use trading_runtime::{
-    ClosedPosition, ExecutionAction, ForceCloseIgnoredReason, IgnoredDecisionReason,
+    ClosedPosition, ExecutionAction, ExitKind, ForceCloseIgnoredReason, IgnoredDecisionReason,
     PortfolioState, PredeterminedStrategyHandler, RuntimeEvent, RuntimePortfolioSnapshot,
     StrategyDecision, StrategyDecisionIntent, TradingRuntime,
 };
@@ -587,6 +587,7 @@ fn primary_candle_closes_long_position_and_realizes_pnl() {
             },
             RuntimeEvent::PositionClosed {
                 closed_position: expected_closed,
+                exit_kind: ExitKind::StrategyExit,
             },
             RuntimeEvent::PortfolioUpdated {
                 snapshot: expected_snapshot.clone(),
@@ -819,6 +820,7 @@ fn primary_candle_closes_short_position_and_realizes_pnl() {
             },
             RuntimeEvent::PositionClosed {
                 closed_position: expected_closed,
+                exit_kind: ExitKind::StrategyExit,
             },
             RuntimeEvent::PortfolioUpdated {
                 snapshot: expected_snapshot.clone(),
@@ -876,6 +878,7 @@ fn force_close_closes_open_long_position_with_ordered_events() {
             },
             RuntimeEvent::PositionClosed {
                 closed_position: expected_closed,
+                exit_kind: ExitKind::ForceClose,
             },
             RuntimeEvent::PortfolioUpdated {
                 snapshot: expected_snapshot.clone(),
@@ -933,6 +936,7 @@ fn force_close_closes_open_short_position_with_ordered_events() {
             },
             RuntimeEvent::PositionClosed {
                 closed_position: expected_closed,
+                exit_kind: ExitKind::ForceClose,
             },
             RuntimeEvent::PortfolioUpdated {
                 snapshot: expected_snapshot.clone(),
@@ -1038,6 +1042,7 @@ fn force_close_works_while_runtime_is_still_in_warmup() {
             },
             RuntimeEvent::PositionClosed {
                 closed_position: expected_closed,
+                exit_kind: ExitKind::ForceClose,
             },
             RuntimeEvent::PortfolioUpdated {
                 snapshot: expected_snapshot.clone(),


### PR DESCRIPTION
## Summary

Implements the runtime-managed risk exit AFK follow-up series from #33 / #43:

- #44 pure risk-exit selection and gap-aware pricing
- #45 entry risk parameter validation on opening decisions
- #46 explicit exit-price portfolio closes
- #47 typed exit categories on PositionClosed events
- #48 Warmup Input vs Tradable Candle runtime boundary
- #49 risk exits before strategy ticks on Tradable Candles
- #50 regression coverage for stop/target execution semantics

Closes #33
Refs #43

## Validation

- `cargo test -p trading-runtime`
- `cargo test -p trading-runtime --test risk_exit_regressions`
- `cargo test -p backtester`
- `cargo fmt -p trading-runtime --check`
- `cargo fmt -p backtester --check`
- `git diff --check`

## Notes

- No DB, runner, daemon, UI, buying-power, dynamic-risk-update, or execution-cost migration included.
- #49 and #50 received mandatory review passes before commit.
