### PR TITLE
feat(runtime): add multi-timeframe market input boundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build output
 /target/
+.pi/
 .claude
 # Cargo lock is committed for binaries, kept for reproducibility
 # Cargo.lock  ← intentionally NOT ignored (workspace with binaries)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,6 +84,10 @@ _Avoid_: Warmup Input, historical preload
 The origin of candles that drive a run. Live trading uses a provider-backed source that fetches new candles over time; backtesting uses a historical source that replays stored candles.
 _Avoid_: Engine, Strategy
 
+**Candle Timestamp**:
+The timestamp that identifies a completed candle at the close/end boundary of its interval. Trading Runtime freshness checks, Market State ordering, and Strategy Tick timing interpret Candle Timestamps as close timestamps; provider adapters that receive open timestamps must normalize them before runtime ingestion.
+_Avoid_: Open timestamp, provider raw timestamp when runtime semantics are meant
+
 **Strategy Tick**:
 A Tradable Candle on which the strategy is actually evaluated. Risk Exits can close a position on a Tradable Candle without producing a Strategy Tick. A Tradable Candle can also fail to produce a Strategy Tick when required market context is unavailable.
 _Avoid_: Tradable Candle when the distinction from strategy evaluation matters, Tradable Tick

--- a/backtester/src/lib.rs
+++ b/backtester/src/lib.rs
@@ -456,7 +456,7 @@ mod tests {
             low: close - 1.0,
             close,
             volume: 1000.0,
-            timeframe: "1d".into(),
+            timeframe: "1d".parse().unwrap(),
         }
     }
 

--- a/backtester/src/plan.rs
+++ b/backtester/src/plan.rs
@@ -207,7 +207,7 @@ mod tests {
             low: close - 1.0,
             close,
             volume: 1000.0,
-            timeframe: "1d".into(),
+            timeframe: "1d".parse().unwrap(),
         }
     }
 

--- a/db-layer/src/models.rs
+++ b/db-layer/src/models.rs
@@ -3,7 +3,7 @@
 /// The generated `module_bindings::Candle`, `LivePosition`, `LiveTrade` structs
 /// are the canonical DB types.  `shared::Candle` / `shared::Position` are the
 /// lightweight in-memory types used by the engine and backtester.
-use shared::{Candle, Position, PositionSide};
+use shared::{Candle, Position, PositionSide, Timeframe};
 
 use crate::module_bindings::{Candle as DbCandle, LivePosition};
 
@@ -21,7 +21,7 @@ pub fn candle_to_reducer_args(
     provider: &str,
 ) -> (String, i64, String, f64, f64, f64, f64, f64, String, String) {
     (
-        canonical_id(&c.symbol, &c.timeframe, c.timestamp),
+        canonical_id(&c.symbol, &c.timeframe.to_string(), c.timestamp),
         c.timestamp,
         c.symbol.clone(),
         c.open,
@@ -29,7 +29,7 @@ pub fn candle_to_reducer_args(
         c.low,
         c.close,
         c.volume,
-        c.timeframe.clone(),
+        c.timeframe.to_string(),
         provider.to_string(),
     )
 }
@@ -44,7 +44,10 @@ pub fn db_candle_to_shared(c: DbCandle) -> Candle {
         low: c.low,
         close: c.close,
         volume: c.volume,
-        timeframe: c.timeframe,
+        timeframe: c
+            .timeframe
+            .parse::<Timeframe>()
+            .expect("DB candle timeframe should be canonical"),
     }
 }
 

--- a/db-layer/tests/integration.rs
+++ b/db-layer/tests/integration.rs
@@ -14,7 +14,7 @@ use db_layer::{
     get_candles, get_candles_before, get_open_position, get_trades, insert_candle, insert_trade,
     open_position, SpacetimeClient,
 };
-use shared::Candle;
+use shared::{Candle, Timeframe};
 
 fn integration_enabled() -> bool {
     std::env::var("SPACETIMEDB_INTEGRATION").as_deref() == Ok("1")
@@ -40,7 +40,7 @@ fn make_candle(ts: i64, close: f64) -> Candle {
         low: close - 1.0,
         close,
         volume: 1000.0,
-        timeframe: TF.into(),
+        timeframe: TF.parse::<Timeframe>().unwrap(),
     }
 }
 
@@ -224,7 +224,7 @@ fn db_candle_converts_to_shared() {
         low: 149.0,
         close: 150.0,
         volume: 1_000_000.0,
-        timeframe: "1d".into(),
+        timeframe: "1d".parse().unwrap(),
         provider: "yahoo".into(),
     };
     let shared = db_candle_to_shared(db);

--- a/docs/adr/0004-runtime-refactor-does-not-preserve-legacy-compatibility.md
+++ b/docs/adr/0004-runtime-refactor-does-not-preserve-legacy-compatibility.md
@@ -1,0 +1,6 @@
+# Runtime refactor does not preserve legacy compatibility by default
+
+- Status: accepted
+- Date: 2026-05-28
+
+During the Trading Runtime refactor, documented target architecture and domain language take precedence over preserving old public APIs, event names, or compatibility constructors. Temporary compatibility layers are allowed only when explicitly documented as temporary and paired with a removal criterion, because otherwise they obscure the runtime boundary and invite future code to depend on transitional shapes instead of the intended Trading Runtime model.

--- a/engine/src/bindings.rs
+++ b/engine/src/bindings.rs
@@ -21,7 +21,13 @@ use crate::indicator_cache::{
 };
 
 use indicators::{
-    momentum::{cci::cci, roc::roc, rsi::rsi, stochastic::{stochastic_fast, stochastic_full, stochastic_slow}, williams_r::williams_r},
+    momentum::{
+        cci::cci,
+        roc::roc,
+        rsi::rsi,
+        stochastic::{stochastic_fast, stochastic_full, stochastic_slow},
+        williams_r::williams_r,
+    },
     slope::slope,
     support_resistance::{fibonacci::fibonacci_retracements, pivot_points::pivot_points},
     trend::{
@@ -437,7 +443,12 @@ pub fn build_indicators_module() -> Module {
     m.set_native_fn(
         "stochastic_full",
         |cl: &mut CandleList, period: INT, k_smooth: INT| -> RhaiResult {
-            match stochastic_full(&candles_slice(cl, 0), period as usize, Some(k_smooth as usize), None) {
+            match stochastic_full(
+                &candles_slice(cl, 0),
+                period as usize,
+                Some(k_smooth as usize),
+                None,
+            ) {
                 None => Ok(Dynamic::UNIT),
                 Some(r) => {
                     let mut map = rhai::Map::new();
@@ -451,7 +462,12 @@ pub fn build_indicators_module() -> Module {
     m.set_native_fn(
         "stochastic_full",
         |cl: &mut CandleList, period: INT, k_smooth: INT, d_period: INT| -> RhaiResult {
-            match stochastic_full(&candles_slice(cl, 0), period as usize, Some(k_smooth as usize), Some(d_period as usize)) {
+            match stochastic_full(
+                &candles_slice(cl, 0),
+                period as usize,
+                Some(k_smooth as usize),
+                Some(d_period as usize),
+            ) {
                 None => Ok(Dynamic::UNIT),
                 Some(r) => {
                     let mut map = rhai::Map::new();
@@ -464,8 +480,18 @@ pub fn build_indicators_module() -> Module {
     );
     m.set_native_fn(
         "stochastic_full",
-        |cl: &mut CandleList, period: INT, k_smooth: INT, d_period: INT, offset: INT| -> RhaiResult {
-            match stochastic_full(&candles_slice(cl, offset as usize), period as usize, Some(k_smooth as usize), Some(d_period as usize)) {
+        |cl: &mut CandleList,
+         period: INT,
+         k_smooth: INT,
+         d_period: INT,
+         offset: INT|
+         -> RhaiResult {
+            match stochastic_full(
+                &candles_slice(cl, offset as usize),
+                period as usize,
+                Some(k_smooth as usize),
+                Some(d_period as usize),
+            ) {
                 None => Ok(Dynamic::UNIT),
                 Some(r) => {
                     let mut map = rhai::Map::new();

--- a/engine/src/vm.rs
+++ b/engine/src/vm.rs
@@ -214,7 +214,7 @@ mod tests {
             low: close - 1.0,
             close,
             volume: 1000.0,
-            timeframe: "1d".into(),
+            timeframe: "1d".parse().unwrap(),
         }
     }
 
@@ -923,7 +923,7 @@ fn on_tick(candles, context) {
             low: l,
             close: c,
             volume: 1.0,
-            timeframe: "1m".into(),
+            timeframe: "1m".parse().unwrap(),
         }
     }
 

--- a/engine/src/vm.rs
+++ b/engine/src/vm.rs
@@ -878,7 +878,10 @@ fn on_tick(candles, context) {
     fn adx_offset_matches_previous_tick_values() {
         let mut e = Engine::new(ADX_OFFSET_SEMANTICS).unwrap();
         let mut last = Signal::Hold;
-        for (i, close) in [10.0, 11.0, 12.0, 13.0, 12.0, 14.0, 15.0, 14.5].into_iter().enumerate() {
+        for (i, close) in [10.0, 11.0, 12.0, 13.0, 12.0, 14.0, 15.0, 14.5]
+            .into_iter()
+            .enumerate()
+        {
             let d = e.tick(make_candle(close, i as i64), flat_ctx()).unwrap();
             last = d.signal;
         }

--- a/engine/src/warmup.rs
+++ b/engine/src/warmup.rs
@@ -29,7 +29,7 @@ mod tests {
             low: close - 1.0,
             close,
             volume: 1000.0,
-            timeframe: "1d".into(),
+            timeframe: "1d".parse().unwrap(),
         }
     }
 

--- a/engine/src/warmup_detector.rs
+++ b/engine/src/warmup_detector.rs
@@ -75,8 +75,8 @@ fn warmup_hint_for_call(call: &FnCallExpr, scope: &Scope) -> Option<usize> {
 
     match call.name.as_str() {
         // Single-period indicators
-        "sma" | "ema" | "dema" | "tema" | "adx" | "rsi" | "cci" | "williams_r"
-        | "roc" | "atr" | "mfi" | "slope" | "bollinger" | "keltner" => arg(call, 1, scope),
+        "sma" | "ema" | "dema" | "tema" | "adx" | "rsi" | "cci" | "williams_r" | "roc" | "atr"
+        | "mfi" | "slope" | "bollinger" | "keltner" => arg(call, 1, scope),
 
         // Stochastic variants
         "stochastic_fast" => arg(call, 1, scope),

--- a/indicators/src/anchored/detectors/pivot.rs
+++ b/indicators/src/anchored/detectors/pivot.rs
@@ -107,7 +107,7 @@ mod tests {
             low: l,
             close: (h + l) / 2.0,
             volume: 1.0,
-            timeframe: "1m".into(),
+            timeframe: "1m".parse().unwrap(),
         }
     }
 
@@ -148,7 +148,7 @@ mod tests {
                 low: l,
                 close: l,
                 volume: 1.0,
-                timeframe: "1m".into(),
+                timeframe: "1m".parse().unwrap(),
             };
             if let Some(ev) = det.on_candle(&c, i as u64) {
                 hits.push(ev);

--- a/indicators/src/anchored/detectors/session.rs
+++ b/indicators/src/anchored/detectors/session.rs
@@ -98,7 +98,7 @@ mod tests {
             low: 1.0,
             close: 1.0,
             volume: 0.0,
-            timeframe: "1m".into(),
+            timeframe: "1m".parse().unwrap(),
         }
     }
 

--- a/indicators/src/anchored/evaluators/slope_seg.rs
+++ b/indicators/src/anchored/evaluators/slope_seg.rs
@@ -35,7 +35,7 @@ mod tests {
             low: close,
             close,
             volume: 0.0,
-            timeframe: "1m".into(),
+            timeframe: "1m".parse().unwrap(),
         }
     }
 

--- a/indicators/src/anchored/evaluators/trendline.rs
+++ b/indicators/src/anchored/evaluators/trendline.rs
@@ -250,7 +250,7 @@ mod tests {
             low: close,
             close,
             volume: 0.0,
-            timeframe: "1m".into(),
+            timeframe: "1m".parse().unwrap(),
         }
     }
 

--- a/indicators/src/momentum/cci.rs
+++ b/indicators/src/momentum/cci.rs
@@ -42,7 +42,7 @@ mod tests {
             low: l,
             close: c,
             volume: 1.0,
-            timeframe: "1d".into(),
+            timeframe: "1d".parse().unwrap(),
         }
     }
 

--- a/indicators/src/momentum/stochastic.rs
+++ b/indicators/src/momentum/stochastic.rs
@@ -143,7 +143,7 @@ mod tests {
             low: l,
             close: c,
             volume: 1.0,
-            timeframe: "1d".into(),
+            timeframe: "1d".parse().unwrap(),
         }
     }
 

--- a/indicators/src/momentum/williams_r.rs
+++ b/indicators/src/momentum/williams_r.rs
@@ -41,7 +41,7 @@ mod tests {
             low: l,
             close: c,
             volume: 1.0,
-            timeframe: "1d".into(),
+            timeframe: "1d".parse().unwrap(),
         }
     }
 

--- a/indicators/src/support_resistance/pivot_points.rs
+++ b/indicators/src/support_resistance/pivot_points.rs
@@ -47,7 +47,7 @@ mod tests {
             low: l,
             close: c,
             volume: 1.0,
-            timeframe: "1d".into(),
+            timeframe: "1d".parse().unwrap(),
         }
     }
 

--- a/indicators/src/trend/adx.rs
+++ b/indicators/src/trend/adx.rs
@@ -116,7 +116,7 @@ mod tests {
             low: l,
             close: c,
             volume: 1.0,
-            timeframe: "1d".into(),
+            timeframe: "1d".parse().unwrap(),
         }
     }
 

--- a/indicators/src/trend/ichimoku.rs
+++ b/indicators/src/trend/ichimoku.rs
@@ -84,7 +84,7 @@ mod tests {
             low: l,
             close: c,
             volume: 1.0,
-            timeframe: "1d".into(),
+            timeframe: "1d".parse().unwrap(),
         }
     }
 

--- a/indicators/src/trend/sar.rs
+++ b/indicators/src/trend/sar.rs
@@ -92,7 +92,11 @@ pub fn sar(candles: &[Candle], step: f64, max: f64) -> Option<SarResult> {
 
     Some(SarResult {
         value: sar,
-        side: if is_long { SarSide::Long } else { SarSide::Short },
+        side: if is_long {
+            SarSide::Long
+        } else {
+            SarSide::Short
+        },
         reversed,
         ep,
         af,

--- a/indicators/src/trend/sar.rs
+++ b/indicators/src/trend/sar.rs
@@ -116,7 +116,7 @@ mod tests {
             low: l,
             close: c,
             volume: 1.0,
-            timeframe: "1d".into(),
+            timeframe: "1d".parse().unwrap(),
         }
     }
 

--- a/indicators/src/volatility/atr.rs
+++ b/indicators/src/volatility/atr.rs
@@ -71,7 +71,7 @@ mod tests {
             low: l,
             close: c,
             volume: 1.0,
-            timeframe: "1d".into(),
+            timeframe: "1d".parse().unwrap(),
         }
     }
 

--- a/indicators/src/volatility/keltner.rs
+++ b/indicators/src/volatility/keltner.rs
@@ -49,7 +49,7 @@ mod tests {
             low: l,
             close: c,
             volume: 1.0,
-            timeframe: "1d".into(),
+            timeframe: "1d".parse().unwrap(),
         }
     }
 

--- a/indicators/src/volume/mfi.rs
+++ b/indicators/src/volume/mfi.rs
@@ -48,7 +48,7 @@ mod tests {
             low: l,
             close: c,
             volume: v,
-            timeframe: "1d".into(),
+            timeframe: "1d".parse().unwrap(),
         }
     }
 

--- a/indicators/src/volume/obv.rs
+++ b/indicators/src/volume/obv.rs
@@ -35,7 +35,7 @@ mod tests {
             low: c - 0.5,
             close: c,
             volume: v,
-            timeframe: "1d".into(),
+            timeframe: "1d".parse().unwrap(),
         }
     }
 

--- a/indicators/src/volume/volume_profile.rs
+++ b/indicators/src/volume/volume_profile.rs
@@ -74,7 +74,7 @@ mod tests {
             low: l,
             close: (h + l) / 2.0,
             volume: v,
-            timeframe: "1d".into(),
+            timeframe: "1d".parse().unwrap(),
         }
     }
 

--- a/indicators/src/volume/vwap.rs
+++ b/indicators/src/volume/vwap.rs
@@ -31,7 +31,7 @@ mod tests {
             low: l,
             close: c,
             volume: v,
-            timeframe: "1d".into(),
+            timeframe: "1d".parse().unwrap(),
         }
     }
 

--- a/shared/src/candle.rs
+++ b/shared/src/candle.rs
@@ -1,3 +1,4 @@
+use crate::Timeframe;
 use serde::{Deserialize, Serialize};
 
 /// A single OHLCV candlestick.
@@ -17,8 +18,8 @@ pub struct Candle {
     pub close: f64,
     /// Fractional-safe volume (covers stocks + crypto).
     pub volume: f64,
-    /// Timeframe string, e.g. `"1m"`, `"5m"`, `"1h"`, `"1d"`.
-    pub timeframe: String,
+    /// Canonical candle timeframe, e.g. `1m`, `5m`, `1h`, `1d`.
+    pub timeframe: Timeframe,
 }
 
 impl Candle {
@@ -46,7 +47,7 @@ mod tests {
             low: 90.0,
             close: 105.0,
             volume: 1_000.0,
-            timeframe: "1d".into(),
+            timeframe: Timeframe::days(1),
         }
     }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -3,9 +3,11 @@ pub mod context;
 pub mod executor;
 pub mod position;
 pub mod signal;
+pub mod timeframe;
 
 pub use candle::Candle;
 pub use context::Context;
 pub use executor::{plan_action, realized_pnl, Action};
 pub use position::{Position, PositionSide};
 pub use signal::{Signal, TradeDecision};
+pub use timeframe::{Timeframe, TimeframeParseError, TimeframeUnit};

--- a/shared/src/timeframe.rs
+++ b/shared/src/timeframe.rs
@@ -1,0 +1,203 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{fmt, num::NonZeroU32, str::FromStr};
+use thiserror::Error;
+
+/// Canonical runtime/domain candle timeframe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Timeframe {
+    amount: NonZeroU32,
+    unit: TimeframeUnit,
+}
+
+/// Supported timeframe units in runtime/domain code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TimeframeUnit {
+    Minute,
+    Hour,
+    Day,
+    Week,
+}
+
+/// Error returned when parsing or constructing an invalid timeframe.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum TimeframeParseError {
+    #[error("timeframe cannot be empty")]
+    Empty,
+    #[error("timeframe amount must be a positive integer")]
+    InvalidAmount,
+    #[error("unsupported timeframe unit '{0}'")]
+    UnsupportedUnit(String),
+}
+
+impl Timeframe {
+    pub fn new(amount: NonZeroU32, unit: TimeframeUnit) -> Self {
+        Self { amount, unit }
+    }
+
+    pub fn minutes(amount: u32) -> Self {
+        Self::from_positive_amount(amount, TimeframeUnit::Minute)
+    }
+
+    pub fn hours(amount: u32) -> Self {
+        Self::from_positive_amount(amount, TimeframeUnit::Hour)
+    }
+
+    pub fn days(amount: u32) -> Self {
+        Self::from_positive_amount(amount, TimeframeUnit::Day)
+    }
+
+    pub fn weeks(amount: u32) -> Self {
+        Self::from_positive_amount(amount, TimeframeUnit::Week)
+    }
+
+    pub fn amount(self) -> NonZeroU32 {
+        self.amount
+    }
+
+    pub fn unit(self) -> TimeframeUnit {
+        self.unit
+    }
+
+    /// Duration of one candle for this timeframe in milliseconds.
+    pub fn duration_ms(self) -> i64 {
+        let multiplier = match self.unit {
+            TimeframeUnit::Minute => 60_000_i64,
+            TimeframeUnit::Hour => 3_600_000_i64,
+            TimeframeUnit::Day => 86_400_000_i64,
+            TimeframeUnit::Week => 7 * 86_400_000_i64,
+        };
+
+        i64::from(self.amount.get()) * multiplier
+    }
+
+    fn from_positive_amount(amount: u32, unit: TimeframeUnit) -> Self {
+        Self {
+            amount: NonZeroU32::new(amount).expect("timeframe amount must be positive"),
+            unit,
+        }
+    }
+}
+
+impl fmt::Display for Timeframe {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let unit = match self.unit {
+            TimeframeUnit::Minute => "m",
+            TimeframeUnit::Hour => "h",
+            TimeframeUnit::Day => "d",
+            TimeframeUnit::Week => "w",
+        };
+
+        write!(formatter, "{}{}", self.amount, unit)
+    }
+}
+
+impl FromStr for Timeframe {
+    type Err = TimeframeParseError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        if input.is_empty() {
+            return Err(TimeframeParseError::Empty);
+        }
+
+        let first_unit_index = input
+            .char_indices()
+            .find_map(|(index, character)| (!character.is_ascii_digit()).then_some(index))
+            .ok_or(TimeframeParseError::UnsupportedUnit(String::new()))?;
+
+        let amount_digits = &input[..first_unit_index];
+        if first_unit_index == 0 || amount_digits.starts_with('0') {
+            return Err(TimeframeParseError::InvalidAmount);
+        }
+
+        let amount = amount_digits
+            .parse::<u32>()
+            .ok()
+            .and_then(NonZeroU32::new)
+            .ok_or(TimeframeParseError::InvalidAmount)?;
+
+        let unit_suffix = &input[first_unit_index..];
+        let unit = match unit_suffix {
+            "m" => TimeframeUnit::Minute,
+            "h" => TimeframeUnit::Hour,
+            "d" => TimeframeUnit::Day,
+            "w" => TimeframeUnit::Week,
+            other => return Err(TimeframeParseError::UnsupportedUnit(other.to_owned())),
+        };
+
+        Ok(Self { amount, unit })
+    }
+}
+
+impl Serialize for Timeframe {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Timeframe {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        raw.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_valid_canonical_timeframes() {
+        assert_eq!("1m".parse::<Timeframe>(), Ok(Timeframe::minutes(1)));
+        assert_eq!("15m".parse::<Timeframe>(), Ok(Timeframe::minutes(15)));
+        assert_eq!("1h".parse::<Timeframe>(), Ok(Timeframe::hours(1)));
+        assert_eq!("1d".parse::<Timeframe>(), Ok(Timeframe::days(1)));
+        assert_eq!("1w".parse::<Timeframe>(), Ok(Timeframe::weeks(1)));
+    }
+
+    #[test]
+    fn rejects_invalid_timeframe_strings() {
+        for invalid in ["0m", "01m", "-1m", "15min", "", "1q", "1wk", "m", "1"] {
+            assert!(
+                invalid.parse::<Timeframe>().is_err(),
+                "expected {invalid:?} to be invalid"
+            );
+        }
+    }
+
+    #[test]
+    fn calculates_duration_ms() {
+        assert_eq!(Timeframe::minutes(15).duration_ms(), 15 * 60_000);
+        assert_eq!(Timeframe::hours(1).duration_ms(), 3_600_000);
+        assert_eq!(Timeframe::days(1).duration_ms(), 86_400_000);
+        assert_eq!(Timeframe::weeks(1).duration_ms(), 7 * 86_400_000);
+    }
+
+    #[test]
+    fn display_round_trips_through_from_str() {
+        for timeframe in [
+            Timeframe::minutes(1),
+            Timeframe::minutes(15),
+            Timeframe::hours(1),
+            Timeframe::days(1),
+            Timeframe::weeks(1),
+        ] {
+            assert_eq!(timeframe.to_string().parse::<Timeframe>(), Ok(timeframe));
+        }
+    }
+
+    #[test]
+    fn serde_round_trips_as_canonical_string() {
+        let serialized = serde_json::to_string(&Timeframe::hours(4)).unwrap();
+        assert_eq!(serialized, "\"4h\"");
+        assert_eq!(
+            serde_json::from_str::<Timeframe>(&serialized).unwrap(),
+            Timeframe::hours(4)
+        );
+    }
+}

--- a/trading-daemon/src/live_engine.rs
+++ b/trading-daemon/src/live_engine.rs
@@ -8,7 +8,7 @@ use tracing::{error, info, warn};
 
 use db_layer::{count_trades, module_bindings::CandlesTableAccess, DbConnection, SpacetimeClient};
 use engine::Engine;
-use shared::{Candle, Context, Position};
+use shared::{Candle, Context, Position, Timeframe};
 use spacetimedb_sdk::Table;
 
 use crate::{
@@ -47,6 +47,9 @@ pub async fn run(
     let conn: Arc<DbConnection> = client.conn.clone();
     let warmup = warmup_engine(&conn, &mut engine, &symbol, &interval, warmup_bars)?;
     let warmup_high_water = warmup.high_water_ts;
+    let runtime_timeframe: Timeframe = interval
+        .parse()
+        .map_err(|e| anyhow::anyhow!("Invalid configured interval '{}': {e}", interval))?;
 
     // ── Create paper executor (restores open position from DB cache) ───────────
     let mut executor = PaperExecutor::new(
@@ -68,7 +71,7 @@ pub async fn run(
     let (tx, mut rx) = mpsc::channel::<Candle>(64);
 
     let sym_filter = symbol.clone();
-    let tf_filter = interval.clone();
+    let tf_filter = runtime_timeframe.to_string();
 
     conn.db.candles().on_insert(move |_ctx, db_candle| {
         if db_candle.symbol != sym_filter || db_candle.timeframe != tf_filter {
@@ -88,7 +91,7 @@ pub async fn run(
             low: db_candle.low,
             close: db_candle.close,
             volume: db_candle.volume,
-            timeframe: db_candle.timeframe.clone(),
+            timeframe: runtime_timeframe,
         };
         if let Err(e) = tx.try_send(candle) {
             warn!(error = %e, "Dropped candle — engine channel full");

--- a/trading-daemon/src/seed/mod.rs
+++ b/trading-daemon/src/seed/mod.rs
@@ -112,10 +112,14 @@ async fn seed_one(
     // Fetch the full requested range from Yahoo, then drop timestamps we
     // already have in the cache. This lets us backfill older history when
     // the user passes a `--from` earlier than our oldest stored bar.
-    let existing = count_candles(&*conn, symbol, interval);
-    let existing_ts = get_candle_timestamps(&*conn, symbol, interval);
+    let canonical_interval = yahoo::interval_timeframe(interval)?.to_string();
+    let existing = count_candles(&*conn, symbol, &canonical_interval);
+    let existing_ts = get_candle_timestamps(&*conn, symbol, &canonical_interval);
 
-    info!(symbol, interval, existing, from_ms, "Seeding");
+    info!(
+        symbol,
+        interval, canonical_interval, existing, from_ms, "Seeding"
+    );
 
     let candles = yahoo::fetch_candles(http, symbol, interval, from_ms).await?;
 

--- a/trading-daemon/src/seed/yahoo.rs
+++ b/trading-daemon/src/seed/yahoo.rs
@@ -4,7 +4,7 @@
 /// (incomplete) candle when the current candle period has not yet closed.
 use anyhow::{anyhow, Result};
 use serde::Deserialize;
-use shared::Candle;
+use shared::{Candle, Timeframe};
 
 /// Yahoo Finance chart API response.
 #[derive(Debug, Deserialize)]
@@ -40,19 +40,19 @@ struct YahooQuote {
 
 // ── Interval helpers ──────────────────────────────────────────────────────────
 
-/// Convert a timeframe string to milliseconds.
-pub fn interval_ms(interval: &str) -> i64 {
+/// Parse a Yahoo interval into the canonical runtime/domain timeframe.
+pub fn interval_timeframe(interval: &str) -> Result<Timeframe> {
     match interval {
-        "1m" => 60_000,
-        "5m" => 5 * 60_000,
-        "15m" => 15 * 60_000,
-        "30m" => 30 * 60_000,
-        "1h" => 3_600_000,
-        "4h" => 4 * 3_600_000,
-        "1d" => 86_400_000,
-        "1wk" => 7 * 86_400_000,
-        _ => 86_400_000, // default to 1d
+        "1wk" => Ok(Timeframe::weeks(1)),
+        canonical => canonical
+            .parse()
+            .map_err(|e| anyhow!("Unsupported Yahoo interval '{interval}': {e}")),
     }
+}
+
+/// Convert a timeframe string to milliseconds.
+pub fn interval_ms(interval: &str) -> Result<i64> {
+    Ok(interval_timeframe(interval)?.duration_ms())
 }
 
 // ── Main fetch function ───────────────────────────────────────────────────────
@@ -119,9 +119,9 @@ pub async fn fetch_candles(
         .next()
         .ok_or_else(|| anyhow!("No quote data in Yahoo response"))?;
 
-    let int_ms = interval_ms(interval);
+    let timeframe = interval_timeframe(interval)?;
+    let int_ms = interval_ms(interval)?;
     let symbol_str = symbol.to_string();
-    let tf_str = interval.to_string();
 
     let mut candles: Vec<Candle> = timestamps
         .iter()
@@ -158,7 +158,7 @@ pub async fn fetch_candles(
                 low,
                 close,
                 volume,
-                timeframe: tf_str.clone(),
+                timeframe,
             })
         })
         .collect();

--- a/trading-daemon/tests/integration.rs
+++ b/trading-daemon/tests/integration.rs
@@ -39,7 +39,7 @@ fn make_candle(ts: i64, close: f64) -> Candle {
         low: close - 1.0,
         close,
         volume: 1000.0,
-        timeframe: "1d".into(),
+        timeframe: "1d".parse().unwrap(),
     }
 }
 

--- a/trading-runtime/src/decision.rs
+++ b/trading-runtime/src/decision.rs
@@ -1,6 +1,6 @@
-//! Strategy-produced decisions for a tradable runtime tick.
+//! Strategy-produced decisions for a Strategy Tick.
 
-/// Direction-aware strategy intent for one tradable tick.
+/// Direction-aware strategy intent for one Strategy Tick.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StrategyDecisionIntent {
     Hold,

--- a/trading-runtime/src/events.rs
+++ b/trading-runtime/src/events.rs
@@ -20,6 +20,13 @@ pub enum ExitKind {
     ForceClose,
 }
 
+/// Why a Primary-Timeframe Tradable Candle did not become a Strategy Tick.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StrategyTickBlockedReason {
+    RequiredSecondaryUnavailable { timeframe: String },
+    RequiredSecondaryStale { timeframe: String },
+}
+
 /// A runner-neutral occurrence emitted by the trading runtime.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RuntimeEvent {
@@ -29,8 +36,15 @@ pub enum RuntimeEvent {
     WarmupInputAccepted {
         candle: Candle,
     },
-    TradableTickStarted {
+    TradableCandleAccepted {
         candle: Candle,
+    },
+    StrategyTickStarted {
+        candle: Candle,
+    },
+    StrategyTickBlocked {
+        candle: Candle,
+        reason: StrategyTickBlockedReason,
     },
     StrategyDecisionProduced {
         decision: StrategyDecision,
@@ -55,7 +69,8 @@ pub enum RuntimeEvent {
     PortfolioUpdated {
         snapshot: RuntimePortfolioSnapshot,
     },
-    TradableTickCompleted,
+    StrategyTickCompleted,
+    TradableCandleCompleted,
     WarmupAdvanced {
         timeframe: String,
         current_warmup_input_count: usize,

--- a/trading-runtime/src/events.rs
+++ b/trading-runtime/src/events.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     ClosedPosition, ExecutionAction, IgnoredDecisionReason, RiskExitKind, RiskExitTriggered,
-    RuntimePortfolioSnapshot, StrategyDecision,
+    RuntimePortfolioSnapshot, SecondaryReadiness, StrategyDecision,
 };
 use shared::{Candle, Position};
 
@@ -18,6 +18,13 @@ pub enum ExitKind {
     StrategyExit,
     RiskExit { selected: RiskExitKind },
     ForceClose,
+}
+
+/// Why Secondary-Timeframe context is unavailable for a Primary Strategy Tick.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecondaryContextUnavailableReason {
+    Missing,
+    Stale,
 }
 
 /// Why a Primary-Timeframe Tradable Candle did not become a Strategy Tick.
@@ -45,6 +52,12 @@ pub enum RuntimeEvent {
     StrategyTickBlocked {
         candle: Candle,
         reason: StrategyTickBlockedReason,
+    },
+    SecondaryContextUnavailable {
+        candle: Candle,
+        timeframe: String,
+        readiness: SecondaryReadiness,
+        reason: SecondaryContextUnavailableReason,
     },
     StrategyDecisionProduced {
         decision: StrategyDecision,

--- a/trading-runtime/src/events.rs
+++ b/trading-runtime/src/events.rs
@@ -57,11 +57,13 @@ pub enum RuntimeEvent {
     },
     TradableTickCompleted,
     WarmupAdvanced {
+        timeframe: String,
         current_warmup_input_count: usize,
         required_warmup_inputs: usize,
     },
     WarmupCompleted {
-        completed_warmup_input_count: usize,
+        completed_timeframes: Vec<String>,
+        required_warmup_inputs: usize,
     },
     ForceCloseRequested {
         candle: Candle,

--- a/trading-runtime/src/events.rs
+++ b/trading-runtime/src/events.rs
@@ -27,11 +27,11 @@ pub enum SecondaryContextUnavailableReason {
     Stale,
 }
 
-/// Why a Primary-Timeframe Tradable Candle did not become a Strategy Tick.
+/// Required Secondary-Timeframe context that blocked a Primary Strategy Tick.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum StrategyTickBlockedReason {
-    RequiredSecondaryUnavailable { timeframe: String },
-    RequiredSecondaryStale { timeframe: String },
+pub struct BlockedSecondaryContext {
+    pub timeframe: String,
+    pub reason: SecondaryContextUnavailableReason,
 }
 
 /// A runner-neutral occurrence emitted by the trading runtime.
@@ -51,7 +51,7 @@ pub enum RuntimeEvent {
     },
     StrategyTickBlocked {
         candle: Candle,
-        reason: StrategyTickBlockedReason,
+        blocked_contexts: Vec<BlockedSecondaryContext>,
     },
     SecondaryContextUnavailable {
         candle: Candle,

--- a/trading-runtime/src/events.rs
+++ b/trading-runtime/src/events.rs
@@ -4,7 +4,7 @@ use crate::{
     ClosedPosition, ExecutionAction, IgnoredDecisionReason, RiskExitKind, RiskExitTriggered,
     RuntimePortfolioSnapshot, SecondaryReadiness, StrategyDecision,
 };
-use shared::{Candle, Position};
+use shared::{Candle, Position, Timeframe};
 
 /// Why an explicit runner force-close command did not close a position.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -30,7 +30,7 @@ pub enum SecondaryContextUnavailableReason {
 /// Required Secondary-Timeframe context that blocked a Primary Strategy Tick.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockedSecondaryContext {
-    pub timeframe: String,
+    pub timeframe: Timeframe,
     pub reason: SecondaryContextUnavailableReason,
 }
 
@@ -55,7 +55,7 @@ pub enum RuntimeEvent {
     },
     SecondaryContextUnavailable {
         candle: Candle,
-        timeframe: String,
+        timeframe: Timeframe,
         readiness: SecondaryReadiness,
         reason: SecondaryContextUnavailableReason,
     },
@@ -85,12 +85,12 @@ pub enum RuntimeEvent {
     StrategyTickCompleted,
     TradableCandleCompleted,
     WarmupAdvanced {
-        timeframe: String,
+        timeframe: Timeframe,
         current_warmup_input_count: usize,
         required_warmup_inputs: usize,
     },
     WarmupCompleted {
-        completed_timeframes: Vec<String>,
+        completed_timeframes: Vec<Timeframe>,
         required_warmup_inputs: usize,
     },
     ForceCloseRequested {

--- a/trading-runtime/src/lib.rs
+++ b/trading-runtime/src/lib.rs
@@ -25,9 +25,14 @@ pub mod strategy;
 pub use decision::{
     validate_opening_quantity, InvalidOpeningQuantity, StrategyDecision, StrategyDecisionIntent,
 };
-pub use events::{ExitKind, ForceCloseIgnoredReason, RuntimeEvent, StrategyTickBlockedReason};
+pub use events::{
+    ExitKind, ForceCloseIgnoredReason, RuntimeEvent, SecondaryContextUnavailableReason,
+    StrategyTickBlockedReason,
+};
 pub use execution::{plan_execution, ExecutionAction, IgnoredDecisionReason, PlannedExecution};
-pub use market_input::{MarketInput, RuntimeConfig, RuntimeInputError};
+pub use market_input::{
+    MarketInput, RuntimeConfig, RuntimeInputError, SecondaryReadiness, SecondaryTimeframeConfig,
+};
 pub use market_state::MarketState;
 pub use portfolio::{
     ClosedPosition, PortfolioState, PortfolioTransitionError, RuntimePortfolioSnapshot,

--- a/trading-runtime/src/lib.rs
+++ b/trading-runtime/src/lib.rs
@@ -25,7 +25,7 @@ pub mod strategy;
 pub use decision::{
     validate_opening_quantity, InvalidOpeningQuantity, StrategyDecision, StrategyDecisionIntent,
 };
-pub use events::{ExitKind, ForceCloseIgnoredReason, RuntimeEvent};
+pub use events::{ExitKind, ForceCloseIgnoredReason, RuntimeEvent, StrategyTickBlockedReason};
 pub use execution::{plan_execution, ExecutionAction, IgnoredDecisionReason, PlannedExecution};
 pub use market_input::{MarketInput, RuntimeConfig, RuntimeInputError};
 pub use market_state::MarketState;

--- a/trading-runtime/src/lib.rs
+++ b/trading-runtime/src/lib.rs
@@ -26,8 +26,8 @@ pub use decision::{
     validate_opening_quantity, InvalidOpeningQuantity, StrategyDecision, StrategyDecisionIntent,
 };
 pub use events::{
-    ExitKind, ForceCloseIgnoredReason, RuntimeEvent, SecondaryContextUnavailableReason,
-    StrategyTickBlockedReason,
+    BlockedSecondaryContext, ExitKind, ForceCloseIgnoredReason, RuntimeEvent,
+    SecondaryContextUnavailableReason,
 };
 pub use execution::{plan_execution, ExecutionAction, IgnoredDecisionReason, PlannedExecution};
 pub use market_input::{

--- a/trading-runtime/src/lib.rs
+++ b/trading-runtime/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod decision;
 pub mod events;
 pub mod execution;
+pub mod market_input;
 pub mod portfolio;
 pub mod risk_exit;
 pub mod runtime;
@@ -25,6 +26,7 @@ pub use decision::{
 };
 pub use events::{ExitKind, ForceCloseIgnoredReason, RuntimeEvent};
 pub use execution::{plan_execution, ExecutionAction, IgnoredDecisionReason, PlannedExecution};
+pub use market_input::{MarketInput, RuntimeConfig, RuntimeInputError};
 pub use portfolio::{
     ClosedPosition, PortfolioState, PortfolioTransitionError, RuntimePortfolioSnapshot,
 };

--- a/trading-runtime/src/lib.rs
+++ b/trading-runtime/src/lib.rs
@@ -39,5 +39,6 @@ pub use portfolio::{
 };
 pub use risk_exit::{evaluate_risk_exit, RiskExitKind, RiskExitTriggered};
 pub use runtime::TradingRuntime;
+pub use shared::{Timeframe, TimeframeParseError, TimeframeUnit};
 pub use step::RuntimeStep;
 pub use strategy::{PredeterminedStrategyHandler, StrategyHandler};

--- a/trading-runtime/src/lib.rs
+++ b/trading-runtime/src/lib.rs
@@ -15,6 +15,7 @@ pub mod decision;
 pub mod events;
 pub mod execution;
 pub mod market_input;
+pub mod market_state;
 pub mod portfolio;
 pub mod risk_exit;
 pub mod runtime;
@@ -27,6 +28,7 @@ pub use decision::{
 pub use events::{ExitKind, ForceCloseIgnoredReason, RuntimeEvent};
 pub use execution::{plan_execution, ExecutionAction, IgnoredDecisionReason, PlannedExecution};
 pub use market_input::{MarketInput, RuntimeConfig, RuntimeInputError};
+pub use market_state::MarketState;
 pub use portfolio::{
     ClosedPosition, PortfolioState, PortfolioTransitionError, RuntimePortfolioSnapshot,
 };

--- a/trading-runtime/src/market_input.rs
+++ b/trading-runtime/src/market_input.rs
@@ -44,22 +44,6 @@ pub struct RuntimeConfig {
 }
 
 impl RuntimeConfig {
-    pub fn new<A, P, I, T>(runtime_asset: A, primary_timeframe: P, secondary_timeframes: I) -> Self
-    where
-        A: Into<String>,
-        P: Into<String>,
-        I: IntoIterator<Item = T>,
-        T: Into<String>,
-    {
-        Self::with_secondary_configs(
-            runtime_asset,
-            primary_timeframe,
-            secondary_timeframes
-                .into_iter()
-                .map(|timeframe| SecondaryTimeframeConfig::optional(timeframe, 0)),
-        )
-    }
-
     pub fn with_secondary_configs<A, P, I>(
         runtime_asset: A,
         primary_timeframe: P,

--- a/trading-runtime/src/market_input.rs
+++ b/trading-runtime/src/market_input.rs
@@ -1,0 +1,79 @@
+//! Runtime market-input boundary types.
+
+use shared::Candle;
+
+/// Runtime-owned configuration for one runtime asset's market input boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeConfig {
+    pub runtime_asset: String,
+    pub primary_timeframe: String,
+    pub secondary_timeframes: Vec<String>,
+}
+
+impl RuntimeConfig {
+    pub fn new<A, P, I, T>(runtime_asset: A, primary_timeframe: P, secondary_timeframes: I) -> Self
+    where
+        A: Into<String>,
+        P: Into<String>,
+        I: IntoIterator<Item = T>,
+        T: Into<String>,
+    {
+        Self {
+            runtime_asset: runtime_asset.into(),
+            primary_timeframe: primary_timeframe.into(),
+            secondary_timeframes: secondary_timeframes.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    pub fn single_timeframe(
+        runtime_asset: impl Into<String>,
+        primary_timeframe: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            runtime_asset,
+            primary_timeframe,
+            std::iter::empty::<String>(),
+        )
+    }
+
+    pub(crate) fn classify_timeframe(&self, timeframe: &str) -> Option<MarketInputTimeframeRole> {
+        if timeframe == self.primary_timeframe {
+            Some(MarketInputTimeframeRole::Primary)
+        } else if self
+            .secondary_timeframes
+            .iter()
+            .any(|secondary| secondary == timeframe)
+        {
+            Some(MarketInputTimeframeRole::Secondary)
+        } else {
+            None
+        }
+    }
+}
+
+/// Market input accepted by the runtime boundary.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MarketInput {
+    WarmupCandle(Candle),
+    CompletedCandle(Candle),
+}
+
+impl MarketInput {
+    pub(crate) fn candle(&self) -> &Candle {
+        match self {
+            Self::WarmupCandle(candle) | Self::CompletedCandle(candle) => candle,
+        }
+    }
+}
+
+/// Runtime-boundary errors for invalid runner/runtime market input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeInputError {
+    UnknownTimeframe { timeframe: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MarketInputTimeframeRole {
+    Primary,
+    Secondary,
+}

--- a/trading-runtime/src/market_input.rs
+++ b/trading-runtime/src/market_input.rs
@@ -1,6 +1,6 @@
 //! Runtime market-input boundary types.
 
-use shared::Candle;
+use shared::{Candle, Timeframe};
 
 /// Whether a configured Secondary Timeframe is required for Strategy Ticks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -12,23 +12,23 @@ pub enum SecondaryReadiness {
 /// Runtime configuration for one Secondary Timeframe.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SecondaryTimeframeConfig {
-    pub timeframe: String,
+    pub timeframe: Timeframe,
     pub readiness: SecondaryReadiness,
     pub max_missing_candles: u32,
 }
 
 impl SecondaryTimeframeConfig {
-    pub fn required(timeframe: impl Into<String>, max_missing_candles: u32) -> Self {
+    pub fn required(timeframe: Timeframe, max_missing_candles: u32) -> Self {
         Self {
-            timeframe: timeframe.into(),
+            timeframe,
             readiness: SecondaryReadiness::Required,
             max_missing_candles,
         }
     }
 
-    pub fn optional(timeframe: impl Into<String>, max_missing_candles: u32) -> Self {
+    pub fn optional(timeframe: Timeframe, max_missing_candles: u32) -> Self {
         Self {
-            timeframe: timeframe.into(),
+            timeframe,
             readiness: SecondaryReadiness::Optional,
             max_missing_candles,
         }
@@ -39,31 +39,30 @@ impl SecondaryTimeframeConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeConfig {
     pub runtime_asset: String,
-    pub primary_timeframe: String,
+    pub primary_timeframe: Timeframe,
     pub secondary_timeframes: Vec<SecondaryTimeframeConfig>,
 }
 
 impl RuntimeConfig {
-    pub fn with_secondary_configs<A, P, I>(
+    pub fn with_secondary_configs<A, I>(
         runtime_asset: A,
-        primary_timeframe: P,
+        primary_timeframe: Timeframe,
         secondary_timeframes: I,
     ) -> Self
     where
         A: Into<String>,
-        P: Into<String>,
         I: IntoIterator<Item = SecondaryTimeframeConfig>,
     {
         Self {
             runtime_asset: runtime_asset.into(),
-            primary_timeframe: primary_timeframe.into(),
+            primary_timeframe,
             secondary_timeframes: secondary_timeframes.into_iter().collect(),
         }
     }
 
     pub fn single_timeframe(
         runtime_asset: impl Into<String>,
-        primary_timeframe: impl Into<String>,
+        primary_timeframe: Timeframe,
     ) -> Self {
         Self::with_secondary_configs(
             runtime_asset,
@@ -72,7 +71,10 @@ impl RuntimeConfig {
         )
     }
 
-    pub(crate) fn classify_timeframe(&self, timeframe: &str) -> Option<MarketInputTimeframeRole> {
+    pub(crate) fn classify_timeframe(
+        &self,
+        timeframe: Timeframe,
+    ) -> Option<MarketInputTimeframeRole> {
         if timeframe == self.primary_timeframe {
             Some(MarketInputTimeframeRole::Primary)
         } else if self
@@ -86,13 +88,13 @@ impl RuntimeConfig {
         }
     }
 
-    pub(crate) fn configured_timeframes(&self) -> Vec<String> {
+    pub(crate) fn configured_timeframes(&self) -> Vec<Timeframe> {
         let mut timeframes = Vec::with_capacity(1 + self.secondary_timeframes.len());
-        timeframes.push(self.primary_timeframe.clone());
+        timeframes.push(self.primary_timeframe);
         timeframes.extend(
             self.secondary_timeframes
                 .iter()
-                .map(|secondary| secondary.timeframe.clone()),
+                .map(|secondary| secondary.timeframe),
         );
         timeframes
     }
@@ -120,7 +122,7 @@ impl MarketInput {
 /// Runtime-boundary errors for invalid runner/runtime market input.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeInputError {
-    UnknownTimeframe { timeframe: String },
+    UnknownTimeframe { timeframe: Timeframe },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/trading-runtime/src/market_input.rs
+++ b/trading-runtime/src/market_input.rs
@@ -2,12 +2,45 @@
 
 use shared::Candle;
 
+/// Whether a configured Secondary Timeframe is required for Strategy Ticks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecondaryReadiness {
+    Required,
+    Optional,
+}
+
+/// Runtime configuration for one Secondary Timeframe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecondaryTimeframeConfig {
+    pub timeframe: String,
+    pub readiness: SecondaryReadiness,
+    pub max_missing_candles: u32,
+}
+
+impl SecondaryTimeframeConfig {
+    pub fn required(timeframe: impl Into<String>, max_missing_candles: u32) -> Self {
+        Self {
+            timeframe: timeframe.into(),
+            readiness: SecondaryReadiness::Required,
+            max_missing_candles,
+        }
+    }
+
+    pub fn optional(timeframe: impl Into<String>, max_missing_candles: u32) -> Self {
+        Self {
+            timeframe: timeframe.into(),
+            readiness: SecondaryReadiness::Optional,
+            max_missing_candles,
+        }
+    }
+}
+
 /// Runtime-owned configuration for one runtime asset's market input boundary.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeConfig {
     pub runtime_asset: String,
     pub primary_timeframe: String,
-    pub secondary_timeframes: Vec<String>,
+    pub secondary_timeframes: Vec<SecondaryTimeframeConfig>,
 }
 
 impl RuntimeConfig {
@@ -18,10 +51,29 @@ impl RuntimeConfig {
         I: IntoIterator<Item = T>,
         T: Into<String>,
     {
+        Self::with_secondary_configs(
+            runtime_asset,
+            primary_timeframe,
+            secondary_timeframes
+                .into_iter()
+                .map(|timeframe| SecondaryTimeframeConfig::optional(timeframe, 0)),
+        )
+    }
+
+    pub fn with_secondary_configs<A, P, I>(
+        runtime_asset: A,
+        primary_timeframe: P,
+        secondary_timeframes: I,
+    ) -> Self
+    where
+        A: Into<String>,
+        P: Into<String>,
+        I: IntoIterator<Item = SecondaryTimeframeConfig>,
+    {
         Self {
             runtime_asset: runtime_asset.into(),
             primary_timeframe: primary_timeframe.into(),
-            secondary_timeframes: secondary_timeframes.into_iter().map(Into::into).collect(),
+            secondary_timeframes: secondary_timeframes.into_iter().collect(),
         }
     }
 
@@ -29,10 +81,10 @@ impl RuntimeConfig {
         runtime_asset: impl Into<String>,
         primary_timeframe: impl Into<String>,
     ) -> Self {
-        Self::new(
+        Self::with_secondary_configs(
             runtime_asset,
             primary_timeframe,
-            std::iter::empty::<String>(),
+            std::iter::empty::<SecondaryTimeframeConfig>(),
         )
     }
 
@@ -42,7 +94,7 @@ impl RuntimeConfig {
         } else if self
             .secondary_timeframes
             .iter()
-            .any(|secondary| secondary == timeframe)
+            .any(|secondary| secondary.timeframe == timeframe)
         {
             Some(MarketInputTimeframeRole::Secondary)
         } else {
@@ -53,8 +105,16 @@ impl RuntimeConfig {
     pub(crate) fn configured_timeframes(&self) -> Vec<String> {
         let mut timeframes = Vec::with_capacity(1 + self.secondary_timeframes.len());
         timeframes.push(self.primary_timeframe.clone());
-        timeframes.extend(self.secondary_timeframes.iter().cloned());
+        timeframes.extend(
+            self.secondary_timeframes
+                .iter()
+                .map(|secondary| secondary.timeframe.clone()),
+        );
         timeframes
+    }
+
+    pub(crate) fn secondary_configs(&self) -> &[SecondaryTimeframeConfig] {
+        &self.secondary_timeframes
     }
 }
 

--- a/trading-runtime/src/market_input.rs
+++ b/trading-runtime/src/market_input.rs
@@ -49,6 +49,13 @@ impl RuntimeConfig {
             None
         }
     }
+
+    pub(crate) fn configured_timeframes(&self) -> Vec<String> {
+        let mut timeframes = Vec::with_capacity(1 + self.secondary_timeframes.len());
+        timeframes.push(self.primary_timeframe.clone());
+        timeframes.extend(self.secondary_timeframes.iter().cloned());
+        timeframes
+    }
 }
 
 /// Market input accepted by the runtime boundary.

--- a/trading-runtime/src/market_state.rs
+++ b/trading-runtime/src/market_state.rs
@@ -14,8 +14,10 @@ impl MarketState {
     pub(crate) fn from_config(config: &RuntimeConfig) -> Self {
         let mut histories = HashMap::new();
         histories.insert(config.primary_timeframe.clone(), Vec::new());
-        for timeframe in &config.secondary_timeframes {
-            histories.entry(timeframe.clone()).or_insert_with(Vec::new);
+        for secondary in &config.secondary_timeframes {
+            histories
+                .entry(secondary.timeframe.clone())
+                .or_insert_with(Vec::new);
         }
 
         Self { histories }
@@ -41,5 +43,11 @@ impl MarketState {
         self.histories
             .get(timeframe)
             .map(|history| history.as_slice())
+    }
+
+    pub(crate) fn latest_completed_candle(&self, timeframe: &str) -> Option<&Candle> {
+        self.histories
+            .get(timeframe)
+            .and_then(|history| history.last())
     }
 }

--- a/trading-runtime/src/market_state.rs
+++ b/trading-runtime/src/market_state.rs
@@ -1,22 +1,22 @@
 //! Runtime-owned market history for one runtime asset.
 
 use crate::RuntimeConfig;
-use shared::Candle;
+use shared::{Candle, Timeframe};
 use std::collections::HashMap;
 
 /// DB-free market-data history grouped by configured timeframe.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MarketState {
-    histories: HashMap<String, Vec<Candle>>,
+    histories: HashMap<Timeframe, Vec<Candle>>,
 }
 
 impl MarketState {
     pub(crate) fn from_config(config: &RuntimeConfig) -> Self {
         let mut histories = HashMap::new();
-        histories.insert(config.primary_timeframe.clone(), Vec::new());
+        histories.insert(config.primary_timeframe, Vec::new());
         for secondary in &config.secondary_timeframes {
             histories
-                .entry(secondary.timeframe.clone())
+                .entry(secondary.timeframe)
                 .or_insert_with(Vec::new);
         }
 
@@ -39,15 +39,15 @@ impl MarketState {
     }
 
     /// Inspect a configured timeframe's chronological candle history.
-    pub fn history(&self, timeframe: &str) -> Option<&[Candle]> {
+    pub fn history(&self, timeframe: Timeframe) -> Option<&[Candle]> {
         self.histories
-            .get(timeframe)
+            .get(&timeframe)
             .map(|history| history.as_slice())
     }
 
-    pub(crate) fn latest_completed_candle(&self, timeframe: &str) -> Option<&Candle> {
+    pub(crate) fn latest_completed_candle(&self, timeframe: Timeframe) -> Option<&Candle> {
         self.histories
-            .get(timeframe)
+            .get(&timeframe)
             .and_then(|history| history.last())
     }
 }

--- a/trading-runtime/src/market_state.rs
+++ b/trading-runtime/src/market_state.rs
@@ -1,0 +1,45 @@
+//! Runtime-owned market history for one runtime asset.
+
+use crate::RuntimeConfig;
+use shared::Candle;
+use std::collections::HashMap;
+
+/// DB-free market-data history grouped by configured timeframe.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MarketState {
+    histories: HashMap<String, Vec<Candle>>,
+}
+
+impl MarketState {
+    pub(crate) fn from_config(config: &RuntimeConfig) -> Self {
+        let mut histories = HashMap::new();
+        histories.insert(config.primary_timeframe.clone(), Vec::new());
+        for timeframe in &config.secondary_timeframes {
+            histories.entry(timeframe.clone()).or_insert_with(Vec::new);
+        }
+
+        Self { histories }
+    }
+
+    /// Record accepted market input for a configured timeframe.
+    ///
+    /// Returns false when the timeframe is not configured, allowing compatibility
+    /// wrappers to ignore unvalidated legacy input while `on_market_input` keeps
+    /// returning `RuntimeInputError` before this method is reached.
+    pub(crate) fn record_accepted_candle(&mut self, candle: Candle) -> bool {
+        match self.histories.get_mut(&candle.timeframe) {
+            Some(history) => {
+                history.push(candle);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Inspect a configured timeframe's chronological candle history.
+    pub fn history(&self, timeframe: &str) -> Option<&[Candle]> {
+        self.histories
+            .get(timeframe)
+            .map(|history| history.as_slice())
+    }
+}

--- a/trading-runtime/src/portfolio.rs
+++ b/trading-runtime/src/portfolio.rs
@@ -209,7 +209,7 @@ mod tests {
             low: close,
             close,
             volume: 1_000.0,
-            timeframe: "1m".into(),
+            timeframe: shared::Timeframe::minutes(1),
         }
     }
 

--- a/trading-runtime/src/runtime.rs
+++ b/trading-runtime/src/runtime.rs
@@ -2,10 +2,10 @@
 
 use crate::market_input::MarketInputTimeframeRole;
 use crate::{
-    evaluate_risk_exit, plan_execution, ExecutionAction, ExitKind, ForceCloseIgnoredReason,
-    MarketInput, MarketState, PortfolioState, RuntimeConfig, RuntimeEvent, RuntimeInputError,
-    RuntimeStep, SecondaryContextUnavailableReason, SecondaryReadiness, SecondaryTimeframeConfig,
-    StrategyHandler, StrategyTickBlockedReason,
+    evaluate_risk_exit, plan_execution, BlockedSecondaryContext, ExecutionAction, ExitKind,
+    ForceCloseIgnoredReason, MarketInput, MarketState, PortfolioState, RuntimeConfig, RuntimeEvent,
+    RuntimeInputError, RuntimeStep, SecondaryContextUnavailableReason, SecondaryReadiness,
+    SecondaryTimeframeConfig, StrategyHandler,
 };
 use shared::{Candle, PositionSide};
 use std::collections::HashMap;
@@ -182,10 +182,11 @@ impl<S: StrategyHandler> TradingRuntime<S> {
             return RuntimeStep::new(events, self.portfolio.snapshot(candle.close));
         }
 
-        if let Some(blocked_reason) = self.evaluate_secondary_readiness(&candle, &mut events) {
+        let blocked_contexts = self.evaluate_secondary_readiness(&candle, &mut events);
+        if !blocked_contexts.is_empty() {
             events.push(RuntimeEvent::StrategyTickBlocked {
                 candle: candle.clone(),
-                reason: blocked_reason,
+                blocked_contexts,
             });
             events.push(RuntimeEvent::TradableCandleCompleted);
 
@@ -366,22 +367,16 @@ impl<S: StrategyHandler> TradingRuntime<S> {
         &self,
         primary_candle: &Candle,
         events: &mut Vec<RuntimeEvent>,
-    ) -> Option<StrategyTickBlockedReason> {
+    ) -> Vec<BlockedSecondaryContext> {
+        let mut blocked_contexts = Vec::new();
+
         for secondary in self.config.secondary_configs() {
             if let Some(reason) = self.secondary_unavailable_reason(primary_candle, secondary) {
                 match secondary.readiness {
                     SecondaryReadiness::Required => {
-                        return Some(match reason {
-                            SecondaryContextUnavailableReason::Missing => {
-                                StrategyTickBlockedReason::RequiredSecondaryUnavailable {
-                                    timeframe: secondary.timeframe.clone(),
-                                }
-                            }
-                            SecondaryContextUnavailableReason::Stale => {
-                                StrategyTickBlockedReason::RequiredSecondaryStale {
-                                    timeframe: secondary.timeframe.clone(),
-                                }
-                            }
+                        blocked_contexts.push(BlockedSecondaryContext {
+                            timeframe: secondary.timeframe.clone(),
+                            reason,
                         });
                     }
                     SecondaryReadiness::Optional => {
@@ -396,7 +391,7 @@ impl<S: StrategyHandler> TradingRuntime<S> {
             }
         }
 
-        None
+        blocked_contexts
     }
 
     fn secondary_unavailable_reason(

--- a/trading-runtime/src/runtime.rs
+++ b/trading-runtime/src/runtime.rs
@@ -7,7 +7,7 @@ use crate::{
     RuntimeInputError, RuntimeStep, SecondaryContextUnavailableReason, SecondaryReadiness,
     SecondaryTimeframeConfig, StrategyHandler,
 };
-use shared::{Candle, PositionSide};
+use shared::{Candle, PositionSide, Timeframe};
 use std::collections::HashMap;
 
 /// DB-free trading runtime core for one runtime asset.
@@ -16,7 +16,7 @@ pub struct TradingRuntime<S> {
     config: RuntimeConfig,
     market_state: MarketState,
     portfolio: PortfolioState,
-    warmup_progress: HashMap<String, usize>,
+    warmup_progress: HashMap<Timeframe, usize>,
     warmup_requirement: usize,
     warmup_completed: bool,
     strategy_handler: S,
@@ -25,7 +25,7 @@ pub struct TradingRuntime<S> {
 impl<S: StrategyHandler> TradingRuntime<S> {
     pub fn new(portfolio: PortfolioState, warmup_requirement: usize, strategy_handler: S) -> Self {
         Self::with_config(
-            RuntimeConfig::single_timeframe("BTC-USD", "1m"),
+            RuntimeConfig::single_timeframe("BTC-USD", Timeframe::minutes(1)),
             portfolio,
             warmup_requirement,
             strategy_handler,
@@ -62,9 +62,9 @@ impl<S: StrategyHandler> TradingRuntime<S> {
     ) -> Result<RuntimeStep, RuntimeInputError> {
         let role = self
             .config
-            .classify_timeframe(&input.candle().timeframe)
+            .classify_timeframe(input.candle().timeframe)
             .ok_or_else(|| RuntimeInputError::UnknownTimeframe {
-                timeframe: input.candle().timeframe.clone(),
+                timeframe: input.candle().timeframe,
             })?;
 
         match (input, role) {
@@ -106,8 +106,8 @@ impl<S: StrategyHandler> TradingRuntime<S> {
 
     pub fn on_warmup_input(&mut self, candle: Candle) -> RuntimeStep {
         self.market_state.record_accepted_candle(candle.clone());
-        let timeframe = candle.timeframe.clone();
-        let current_warmup_input_count = self.advance_warmup_progress(&timeframe);
+        let timeframe = candle.timeframe;
+        let current_warmup_input_count = self.advance_warmup_progress(timeframe);
 
         let mut events = vec![RuntimeEvent::WarmupInputAccepted {
             candle: candle.clone(),
@@ -347,11 +347,8 @@ impl<S: StrategyHandler> TradingRuntime<S> {
         self.warmup_requirement
     }
 
-    fn advance_warmup_progress(&mut self, timeframe: &str) -> usize {
-        let count = self
-            .warmup_progress
-            .entry(timeframe.to_owned())
-            .or_insert(0);
+    fn advance_warmup_progress(&mut self, timeframe: Timeframe) -> usize {
+        let count = self.warmup_progress.entry(timeframe).or_insert(0);
         *count += 1;
         *count
     }
@@ -375,14 +372,14 @@ impl<S: StrategyHandler> TradingRuntime<S> {
                 match secondary.readiness {
                     SecondaryReadiness::Required => {
                         blocked_contexts.push(BlockedSecondaryContext {
-                            timeframe: secondary.timeframe.clone(),
+                            timeframe: secondary.timeframe,
                             reason,
                         });
                     }
                     SecondaryReadiness::Optional => {
                         events.push(RuntimeEvent::SecondaryContextUnavailable {
                             candle: primary_candle.clone(),
-                            timeframe: secondary.timeframe.clone(),
+                            timeframe: secondary.timeframe,
                             readiness: secondary.readiness,
                             reason,
                         });
@@ -401,13 +398,11 @@ impl<S: StrategyHandler> TradingRuntime<S> {
     ) -> Option<SecondaryContextUnavailableReason> {
         let Some(latest_secondary) = self
             .market_state
-            .latest_completed_candle(&secondary.timeframe)
+            .latest_completed_candle(secondary.timeframe)
         else {
             return Some(SecondaryContextUnavailableReason::Missing);
         };
-        let Some(duration_ms) = timeframe_duration_ms(&secondary.timeframe) else {
-            return Some(SecondaryContextUnavailableReason::Stale);
-        };
+        let duration_ms = secondary.timeframe.duration_ms();
         let allowed_until = latest_secondary.timestamp.saturating_add(
             duration_ms.saturating_mul(i64::from(secondary.max_missing_candles) + 1),
         );
@@ -417,28 +412,7 @@ impl<S: StrategyHandler> TradingRuntime<S> {
     }
 
     /// Inspect a configured timeframe's chronological Market State history.
-    pub fn market_history(&self, timeframe: &str) -> Option<&[Candle]> {
+    pub fn market_history(&self, timeframe: Timeframe) -> Option<&[Candle]> {
         self.market_state.history(timeframe)
     }
-}
-
-fn timeframe_duration_ms(timeframe: &str) -> Option<i64> {
-    let (number, unit) = split_timeframe(timeframe)?;
-    let multiplier = match unit {
-        "m" => 60_000,
-        "h" => 3_600_000,
-        "d" => 86_400_000,
-        "wk" | "w" => 7 * 86_400_000,
-        _ => return None,
-    };
-
-    number.checked_mul(multiplier)
-}
-
-fn split_timeframe(timeframe: &str) -> Option<(i64, &str)> {
-    let first_unit_index = timeframe
-        .char_indices()
-        .find_map(|(index, character)| (!character.is_ascii_digit()).then_some(index))?;
-    let number = timeframe[..first_unit_index].parse::<i64>().ok()?;
-    (number > 0).then_some((number, &timeframe[first_unit_index..]))
 }

--- a/trading-runtime/src/runtime.rs
+++ b/trading-runtime/src/runtime.rs
@@ -71,7 +71,7 @@ impl<S: StrategyHandler> TradingRuntime<S> {
             (MarketInput::WarmupCandle(candle), _) => Ok(self.on_warmup_input(candle)),
             (MarketInput::CompletedCandle(candle), MarketInputTimeframeRole::Primary) => {
                 if self.is_warmup_complete() {
-                    Ok(self.on_tradable_candle(candle))
+                    Ok(self.handle_completed_primary_after_warmup(candle))
                 } else {
                     Ok(self.on_completed_primary_before_warmup_complete(candle))
                 }
@@ -130,7 +130,7 @@ impl<S: StrategyHandler> TradingRuntime<S> {
         RuntimeStep::new(events, self.portfolio.snapshot(candle.close))
     }
 
-    pub fn on_tradable_candle(&mut self, candle: Candle) -> RuntimeStep {
+    fn handle_completed_primary_after_warmup(&mut self, candle: Candle) -> RuntimeStep {
         self.market_state.record_accepted_candle(candle.clone());
 
         let mut events = vec![RuntimeEvent::MarketInputAccepted {

--- a/trading-runtime/src/runtime.rs
+++ b/trading-runtime/src/runtime.rs
@@ -4,7 +4,8 @@ use crate::market_input::MarketInputTimeframeRole;
 use crate::{
     evaluate_risk_exit, plan_execution, ExecutionAction, ExitKind, ForceCloseIgnoredReason,
     MarketInput, MarketState, PortfolioState, RuntimeConfig, RuntimeEvent, RuntimeInputError,
-    RuntimeStep, StrategyHandler,
+    RuntimeStep, SecondaryContextUnavailableReason, SecondaryReadiness, SecondaryTimeframeConfig,
+    StrategyHandler, StrategyTickBlockedReason,
 };
 use shared::{Candle, PositionSide};
 use std::collections::HashMap;
@@ -181,6 +182,16 @@ impl<S: StrategyHandler> TradingRuntime<S> {
             return RuntimeStep::new(events, self.portfolio.snapshot(candle.close));
         }
 
+        if let Some(blocked_reason) = self.evaluate_secondary_readiness(&candle, &mut events) {
+            events.push(RuntimeEvent::StrategyTickBlocked {
+                candle: candle.clone(),
+                reason: blocked_reason,
+            });
+            events.push(RuntimeEvent::TradableCandleCompleted);
+
+            return RuntimeStep::new(events, self.portfolio.snapshot(candle.close));
+        }
+
         events.push(RuntimeEvent::StrategyTickStarted {
             candle: candle.clone(),
         });
@@ -351,8 +362,88 @@ impl<S: StrategyHandler> TradingRuntime<S> {
             })
     }
 
+    fn evaluate_secondary_readiness(
+        &self,
+        primary_candle: &Candle,
+        events: &mut Vec<RuntimeEvent>,
+    ) -> Option<StrategyTickBlockedReason> {
+        for secondary in self.config.secondary_configs() {
+            if let Some(reason) = self.secondary_unavailable_reason(primary_candle, secondary) {
+                match secondary.readiness {
+                    SecondaryReadiness::Required => {
+                        return Some(match reason {
+                            SecondaryContextUnavailableReason::Missing => {
+                                StrategyTickBlockedReason::RequiredSecondaryUnavailable {
+                                    timeframe: secondary.timeframe.clone(),
+                                }
+                            }
+                            SecondaryContextUnavailableReason::Stale => {
+                                StrategyTickBlockedReason::RequiredSecondaryStale {
+                                    timeframe: secondary.timeframe.clone(),
+                                }
+                            }
+                        });
+                    }
+                    SecondaryReadiness::Optional => {
+                        events.push(RuntimeEvent::SecondaryContextUnavailable {
+                            candle: primary_candle.clone(),
+                            timeframe: secondary.timeframe.clone(),
+                            readiness: secondary.readiness,
+                            reason,
+                        });
+                    }
+                }
+            }
+        }
+
+        None
+    }
+
+    fn secondary_unavailable_reason(
+        &self,
+        primary_candle: &Candle,
+        secondary: &SecondaryTimeframeConfig,
+    ) -> Option<SecondaryContextUnavailableReason> {
+        let Some(latest_secondary) = self
+            .market_state
+            .latest_completed_candle(&secondary.timeframe)
+        else {
+            return Some(SecondaryContextUnavailableReason::Missing);
+        };
+        let Some(duration_ms) = timeframe_duration_ms(&secondary.timeframe) else {
+            return Some(SecondaryContextUnavailableReason::Stale);
+        };
+        let allowed_until = latest_secondary.timestamp.saturating_add(
+            duration_ms.saturating_mul(i64::from(secondary.max_missing_candles) + 1),
+        );
+
+        (primary_candle.timestamp > allowed_until)
+            .then_some(SecondaryContextUnavailableReason::Stale)
+    }
+
     /// Inspect a configured timeframe's chronological Market State history.
     pub fn market_history(&self, timeframe: &str) -> Option<&[Candle]> {
         self.market_state.history(timeframe)
     }
+}
+
+fn timeframe_duration_ms(timeframe: &str) -> Option<i64> {
+    let (number, unit) = split_timeframe(timeframe)?;
+    let multiplier = match unit {
+        "m" => 60_000,
+        "h" => 3_600_000,
+        "d" => 86_400_000,
+        "wk" | "w" => 7 * 86_400_000,
+        _ => return None,
+    };
+
+    number.checked_mul(multiplier)
+}
+
+fn split_timeframe(timeframe: &str) -> Option<(i64, &str)> {
+    let first_unit_index = timeframe
+        .char_indices()
+        .find_map(|(index, character)| (!character.is_ascii_digit()).then_some(index))?;
+    let number = timeframe[..first_unit_index].parse::<i64>().ok()?;
+    (number > 0).then_some((number, &timeframe[first_unit_index..]))
 }

--- a/trading-runtime/src/runtime.rs
+++ b/trading-runtime/src/runtime.rs
@@ -1,14 +1,17 @@
 //! Trading runtime entrypoints.
 
+use crate::market_input::MarketInputTimeframeRole;
 use crate::{
     evaluate_risk_exit, plan_execution, ExecutionAction, ExitKind, ForceCloseIgnoredReason,
-    PortfolioState, RuntimeEvent, RuntimeStep, StrategyHandler,
+    MarketInput, PortfolioState, RuntimeConfig, RuntimeEvent, RuntimeInputError, RuntimeStep,
+    StrategyHandler,
 };
 use shared::{Candle, PositionSide};
 
 /// DB-free trading runtime core for one runtime asset.
 #[derive(Debug, Clone)]
 pub struct TradingRuntime<S> {
+    config: RuntimeConfig,
     portfolio: PortfolioState,
     warmup_input_count: usize,
     warmup_requirement: usize,
@@ -17,12 +20,58 @@ pub struct TradingRuntime<S> {
 
 impl<S: StrategyHandler> TradingRuntime<S> {
     pub fn new(portfolio: PortfolioState, warmup_requirement: usize, strategy_handler: S) -> Self {
+        Self::with_config(
+            RuntimeConfig::single_timeframe("BTC-USD", "1m"),
+            portfolio,
+            warmup_requirement,
+            strategy_handler,
+        )
+    }
+
+    pub fn with_config(
+        config: RuntimeConfig,
+        portfolio: PortfolioState,
+        warmup_requirement: usize,
+        strategy_handler: S,
+    ) -> Self {
         Self {
+            config,
             portfolio,
             warmup_input_count: 0,
             warmup_requirement,
             strategy_handler,
         }
+    }
+
+    pub fn on_market_input(
+        &mut self,
+        input: MarketInput,
+    ) -> Result<RuntimeStep, RuntimeInputError> {
+        let role = self
+            .config
+            .classify_timeframe(&input.candle().timeframe)
+            .ok_or_else(|| RuntimeInputError::UnknownTimeframe {
+                timeframe: input.candle().timeframe.clone(),
+            })?;
+
+        match (input, role) {
+            (MarketInput::WarmupCandle(candle), _) => Ok(self.on_warmup_input(candle)),
+            (MarketInput::CompletedCandle(candle), MarketInputTimeframeRole::Primary) => {
+                Ok(self.on_tradable_candle(candle))
+            }
+            (MarketInput::CompletedCandle(candle), MarketInputTimeframeRole::Secondary) => {
+                Ok(self.on_secondary_completed_candle(candle))
+            }
+        }
+    }
+
+    fn on_secondary_completed_candle(&mut self, candle: Candle) -> RuntimeStep {
+        RuntimeStep::new(
+            vec![RuntimeEvent::MarketInputAccepted {
+                candle: candle.clone(),
+            }],
+            self.portfolio.snapshot(candle.close),
+        )
     }
 
     pub fn on_warmup_input(&mut self, candle: Candle) -> RuntimeStep {

--- a/trading-runtime/src/runtime.rs
+++ b/trading-runtime/src/runtime.rs
@@ -7,6 +7,7 @@ use crate::{
     RuntimeStep, StrategyHandler,
 };
 use shared::{Candle, PositionSide};
+use std::collections::HashMap;
 
 /// DB-free trading runtime core for one runtime asset.
 #[derive(Debug, Clone)]
@@ -14,8 +15,9 @@ pub struct TradingRuntime<S> {
     config: RuntimeConfig,
     market_state: MarketState,
     portfolio: PortfolioState,
-    warmup_input_count: usize,
+    warmup_progress: HashMap<String, usize>,
     warmup_requirement: usize,
+    warmup_completed: bool,
     strategy_handler: S,
 }
 
@@ -36,13 +38,19 @@ impl<S: StrategyHandler> TradingRuntime<S> {
         strategy_handler: S,
     ) -> Self {
         let market_state = MarketState::from_config(&config);
+        let warmup_progress = config
+            .configured_timeframes()
+            .into_iter()
+            .map(|timeframe| (timeframe, 0))
+            .collect();
 
         Self {
             config,
             market_state,
             portfolio,
-            warmup_input_count: 0,
+            warmup_progress,
             warmup_requirement,
+            warmup_completed: warmup_requirement == 0,
             strategy_handler,
         }
     }
@@ -61,12 +69,27 @@ impl<S: StrategyHandler> TradingRuntime<S> {
         match (input, role) {
             (MarketInput::WarmupCandle(candle), _) => Ok(self.on_warmup_input(candle)),
             (MarketInput::CompletedCandle(candle), MarketInputTimeframeRole::Primary) => {
-                Ok(self.on_tradable_candle(candle))
+                if self.is_warmup_complete() {
+                    Ok(self.on_tradable_candle(candle))
+                } else {
+                    Ok(self.on_completed_primary_before_warmup_complete(candle))
+                }
             }
             (MarketInput::CompletedCandle(candle), MarketInputTimeframeRole::Secondary) => {
                 Ok(self.on_secondary_completed_candle(candle))
             }
         }
+    }
+
+    fn on_completed_primary_before_warmup_complete(&mut self, candle: Candle) -> RuntimeStep {
+        self.market_state.record_accepted_candle(candle.clone());
+
+        RuntimeStep::new(
+            vec![RuntimeEvent::MarketInputAccepted {
+                candle: candle.clone(),
+            }],
+            self.portfolio.snapshot(candle.close),
+        )
     }
 
     fn on_secondary_completed_candle(&mut self, candle: Candle) -> RuntimeStep {
@@ -82,20 +105,24 @@ impl<S: StrategyHandler> TradingRuntime<S> {
 
     pub fn on_warmup_input(&mut self, candle: Candle) -> RuntimeStep {
         self.market_state.record_accepted_candle(candle.clone());
-        self.warmup_input_count += 1;
+        let timeframe = candle.timeframe.clone();
+        let current_warmup_input_count = self.advance_warmup_progress(&timeframe);
 
         let mut events = vec![RuntimeEvent::WarmupInputAccepted {
             candle: candle.clone(),
         }];
 
         events.push(RuntimeEvent::WarmupAdvanced {
-            current_warmup_input_count: self.warmup_input_count,
+            timeframe,
+            current_warmup_input_count,
             required_warmup_inputs: self.warmup_requirement,
         });
 
-        if self.warmup_input_count == self.warmup_requirement {
+        if !self.warmup_completed && self.is_warmup_complete() {
+            self.warmup_completed = true;
             events.push(RuntimeEvent::WarmupCompleted {
-                completed_warmup_input_count: self.warmup_input_count,
+                completed_timeframes: self.config.configured_timeframes(),
+                required_warmup_inputs: self.warmup_requirement,
             });
         }
 
@@ -301,6 +328,22 @@ impl<S: StrategyHandler> TradingRuntime<S> {
 
     pub fn warmup_requirement(&self) -> usize {
         self.warmup_requirement
+    }
+
+    fn advance_warmup_progress(&mut self, timeframe: &str) -> usize {
+        let count = self
+            .warmup_progress
+            .entry(timeframe.to_owned())
+            .or_insert(0);
+        *count += 1;
+        *count
+    }
+
+    fn is_warmup_complete(&self) -> bool {
+        self.warmup_requirement == 0
+            || self.config.configured_timeframes().iter().all(|timeframe| {
+                self.warmup_progress.get(timeframe).copied().unwrap_or(0) >= self.warmup_requirement
+            })
     }
 
     /// Inspect a configured timeframe's chronological Market State history.

--- a/trading-runtime/src/runtime.rs
+++ b/trading-runtime/src/runtime.rs
@@ -136,7 +136,7 @@ impl<S: StrategyHandler> TradingRuntime<S> {
             candle: candle.clone(),
         }];
 
-        events.push(RuntimeEvent::TradableTickStarted {
+        events.push(RuntimeEvent::TradableCandleAccepted {
             candle: candle.clone(),
         });
 
@@ -176,10 +176,14 @@ impl<S: StrategyHandler> TradingRuntime<S> {
             events.push(RuntimeEvent::PortfolioUpdated {
                 snapshot: self.portfolio.snapshot(candle.close),
             });
-            events.push(RuntimeEvent::TradableTickCompleted);
+            events.push(RuntimeEvent::TradableCandleCompleted);
 
             return RuntimeStep::new(events, self.portfolio.snapshot(candle.close));
         }
+
+        events.push(RuntimeEvent::StrategyTickStarted {
+            candle: candle.clone(),
+        });
 
         let portfolio_before_decision = self.portfolio.snapshot(candle.close);
         let decision = self
@@ -271,7 +275,8 @@ impl<S: StrategyHandler> TradingRuntime<S> {
             | ExecutionAction::ForceClose => {}
         }
 
-        events.push(RuntimeEvent::TradableTickCompleted);
+        events.push(RuntimeEvent::StrategyTickCompleted);
+        events.push(RuntimeEvent::TradableCandleCompleted);
 
         RuntimeStep::new(events, self.portfolio.snapshot(candle.close))
     }

--- a/trading-runtime/src/runtime.rs
+++ b/trading-runtime/src/runtime.rs
@@ -3,8 +3,8 @@
 use crate::market_input::MarketInputTimeframeRole;
 use crate::{
     evaluate_risk_exit, plan_execution, ExecutionAction, ExitKind, ForceCloseIgnoredReason,
-    MarketInput, PortfolioState, RuntimeConfig, RuntimeEvent, RuntimeInputError, RuntimeStep,
-    StrategyHandler,
+    MarketInput, MarketState, PortfolioState, RuntimeConfig, RuntimeEvent, RuntimeInputError,
+    RuntimeStep, StrategyHandler,
 };
 use shared::{Candle, PositionSide};
 
@@ -12,6 +12,7 @@ use shared::{Candle, PositionSide};
 #[derive(Debug, Clone)]
 pub struct TradingRuntime<S> {
     config: RuntimeConfig,
+    market_state: MarketState,
     portfolio: PortfolioState,
     warmup_input_count: usize,
     warmup_requirement: usize,
@@ -34,8 +35,11 @@ impl<S: StrategyHandler> TradingRuntime<S> {
         warmup_requirement: usize,
         strategy_handler: S,
     ) -> Self {
+        let market_state = MarketState::from_config(&config);
+
         Self {
             config,
+            market_state,
             portfolio,
             warmup_input_count: 0,
             warmup_requirement,
@@ -66,6 +70,8 @@ impl<S: StrategyHandler> TradingRuntime<S> {
     }
 
     fn on_secondary_completed_candle(&mut self, candle: Candle) -> RuntimeStep {
+        self.market_state.record_accepted_candle(candle.clone());
+
         RuntimeStep::new(
             vec![RuntimeEvent::MarketInputAccepted {
                 candle: candle.clone(),
@@ -75,6 +81,7 @@ impl<S: StrategyHandler> TradingRuntime<S> {
     }
 
     pub fn on_warmup_input(&mut self, candle: Candle) -> RuntimeStep {
+        self.market_state.record_accepted_candle(candle.clone());
         self.warmup_input_count += 1;
 
         let mut events = vec![RuntimeEvent::WarmupInputAccepted {
@@ -96,6 +103,8 @@ impl<S: StrategyHandler> TradingRuntime<S> {
     }
 
     pub fn on_tradable_candle(&mut self, candle: Candle) -> RuntimeStep {
+        self.market_state.record_accepted_candle(candle.clone());
+
         let mut events = vec![RuntimeEvent::MarketInputAccepted {
             candle: candle.clone(),
         }];
@@ -292,5 +301,10 @@ impl<S: StrategyHandler> TradingRuntime<S> {
 
     pub fn warmup_requirement(&self) -> usize {
         self.warmup_requirement
+    }
+
+    /// Inspect a configured timeframe's chronological Market State history.
+    pub fn market_history(&self, timeframe: &str) -> Option<&[Candle]> {
+        self.market_state.history(timeframe)
     }
 }

--- a/trading-runtime/tests/market_input.rs
+++ b/trading-runtime/tests/market_input.rs
@@ -1,10 +1,10 @@
 use shared::{Candle, Position, PositionSide};
 use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 use trading_runtime::{
-    ExecutionAction, MarketInput, PortfolioState, RuntimeConfig, RuntimeEvent, RuntimeInputError,
-    RuntimePortfolioSnapshot, SecondaryContextUnavailableReason, SecondaryReadiness,
-    SecondaryTimeframeConfig, StrategyDecision, StrategyHandler, StrategyTickBlockedReason,
-    TradingRuntime,
+    ClosedPosition, ExecutionAction, ExitKind, MarketInput, PortfolioState, RiskExitKind,
+    RiskExitTriggered, RuntimeConfig, RuntimeEvent, RuntimeInputError, RuntimePortfolioSnapshot,
+    SecondaryContextUnavailableReason, SecondaryReadiness, SecondaryTimeframeConfig,
+    StrategyDecision, StrategyHandler, StrategyTickBlockedReason, TradingRuntime,
 };
 
 fn candle(timestamp: i64, timeframe: &str, close: f64) -> Candle {
@@ -785,6 +785,319 @@ fn required_secondary_missing_blocks_strategy_tick_after_storing_primary() {
         RuntimeEvent::StrategyTickStarted { .. }
             | RuntimeEvent::StrategyDecisionProduced { .. }
             | RuntimeEvent::ExecutionActionPlanned { .. }
+    )));
+}
+
+#[test]
+fn long_risk_exit_closes_before_missing_required_secondary_can_block_strategy_tick() {
+    let primary = ohlc_candle(60_000, "1m", 100.0, 105.0, 90.0, 99.0);
+    let open_position = position_with_entry_risk(PositionSide::Long, 100.0, Some(90.0), None);
+    let calls = Rc::new(RefCell::new(0));
+    let mut portfolio = PortfolioState::new(1_000.0);
+    portfolio.open_position = Some(open_position.clone());
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::required("1h", 0)]),
+        portfolio,
+        0,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&calls),
+            [StrategyDecision::close_long()],
+        ),
+    );
+
+    let step = runtime
+        .on_market_input(MarketInput::CompletedCandle(primary.clone()))
+        .unwrap();
+
+    let risk_exit = RiskExitTriggered {
+        side: PositionSide::Long,
+        selected: RiskExitKind::StopLoss,
+        triggered: vec![RiskExitKind::StopLoss],
+        exit_price: 90.0,
+    };
+    let expected_snapshot = RuntimePortfolioSnapshot {
+        realized_cash_balance: 980.0,
+        open_position: None,
+        completed_trade_count: 1,
+        current_equity: 980.0,
+    };
+    assert_eq!(*calls.borrow(), 0);
+    assert_eq!(runtime.market_history("1m"), Some(&[primary.clone()][..]));
+    assert_eq!(runtime.market_history("1h"), Some(&[][..]));
+    assert_eq!(
+        step.events,
+        vec![
+            RuntimeEvent::MarketInputAccepted {
+                candle: primary.clone(),
+            },
+            RuntimeEvent::TradableCandleAccepted {
+                candle: primary.clone(),
+            },
+            RuntimeEvent::RiskExitTriggered {
+                risk_exit: risk_exit.clone(),
+            },
+            RuntimeEvent::ExecutionActionPlanned {
+                action: ExecutionAction::RiskExit {
+                    side: PositionSide::Long,
+                    selected: RiskExitKind::StopLoss,
+                    exit_price: 90.0,
+                },
+            },
+            RuntimeEvent::PositionClosed {
+                closed_position: ClosedPosition {
+                    position: open_position,
+                    exit_price: 90.0,
+                    exit_time: primary.timestamp,
+                    realized_pnl: -20.0,
+                },
+                exit_kind: ExitKind::RiskExit {
+                    selected: RiskExitKind::StopLoss,
+                },
+            },
+            RuntimeEvent::PortfolioUpdated {
+                snapshot: expected_snapshot.clone(),
+            },
+            RuntimeEvent::TradableCandleCompleted,
+        ]
+    );
+    assert_eq!(step.portfolio_snapshot, expected_snapshot);
+    assert!(step.events.iter().all(|event| !matches!(
+        event,
+        RuntimeEvent::StrategyTickBlocked { .. }
+            | RuntimeEvent::StrategyTickStarted { .. }
+            | RuntimeEvent::StrategyDecisionProduced { .. }
+            | RuntimeEvent::StrategyTickCompleted
+    )));
+}
+
+#[test]
+fn short_risk_exit_closes_before_missing_required_secondary_can_block_strategy_tick() {
+    let primary = ohlc_candle(60_000, "1m", 100.0, 105.0, 80.0, 90.0);
+    let open_position = position_with_entry_risk(PositionSide::Short, 100.0, None, Some(80.0));
+    let calls = Rc::new(RefCell::new(0));
+    let mut portfolio = PortfolioState::new(1_000.0);
+    portfolio.open_position = Some(open_position.clone());
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::required("1h", 0)]),
+        portfolio,
+        0,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&calls),
+            [StrategyDecision::close_short()],
+        ),
+    );
+
+    let step = runtime
+        .on_market_input(MarketInput::CompletedCandle(primary.clone()))
+        .unwrap();
+
+    let risk_exit = RiskExitTriggered {
+        side: PositionSide::Short,
+        selected: RiskExitKind::TakeProfit,
+        triggered: vec![RiskExitKind::TakeProfit],
+        exit_price: 80.0,
+    };
+    let expected_snapshot = RuntimePortfolioSnapshot {
+        realized_cash_balance: 1_040.0,
+        open_position: None,
+        completed_trade_count: 1,
+        current_equity: 1_040.0,
+    };
+    assert_eq!(*calls.borrow(), 0);
+    assert_eq!(runtime.market_history("1m"), Some(&[primary.clone()][..]));
+    assert_eq!(runtime.market_history("1h"), Some(&[][..]));
+    assert_eq!(
+        step.events,
+        vec![
+            RuntimeEvent::MarketInputAccepted {
+                candle: primary.clone(),
+            },
+            RuntimeEvent::TradableCandleAccepted {
+                candle: primary.clone(),
+            },
+            RuntimeEvent::RiskExitTriggered {
+                risk_exit: risk_exit.clone(),
+            },
+            RuntimeEvent::ExecutionActionPlanned {
+                action: ExecutionAction::RiskExit {
+                    side: PositionSide::Short,
+                    selected: RiskExitKind::TakeProfit,
+                    exit_price: 80.0,
+                },
+            },
+            RuntimeEvent::PositionClosed {
+                closed_position: ClosedPosition {
+                    position: open_position,
+                    exit_price: 80.0,
+                    exit_time: primary.timestamp,
+                    realized_pnl: 40.0,
+                },
+                exit_kind: ExitKind::RiskExit {
+                    selected: RiskExitKind::TakeProfit,
+                },
+            },
+            RuntimeEvent::PortfolioUpdated {
+                snapshot: expected_snapshot.clone(),
+            },
+            RuntimeEvent::TradableCandleCompleted,
+        ]
+    );
+    assert_eq!(step.portfolio_snapshot, expected_snapshot);
+    assert!(step.events.iter().all(|event| !matches!(
+        event,
+        RuntimeEvent::StrategyTickBlocked { .. }
+            | RuntimeEvent::StrategyTickStarted { .. }
+            | RuntimeEvent::StrategyDecisionProduced { .. }
+            | RuntimeEvent::StrategyTickCompleted
+    )));
+}
+
+#[test]
+fn long_risk_exit_closes_before_stale_required_secondary_can_block_strategy_tick() {
+    let stale_secondary = candle(0, "1h", 100.0);
+    let primary = ohlc_candle(3_600_001, "1m", 100.0, 105.0, 90.0, 99.0);
+    let open_position = position_with_entry_risk(PositionSide::Long, 100.0, Some(90.0), None);
+    let calls = Rc::new(RefCell::new(0));
+    let mut portfolio = PortfolioState::new(1_000.0);
+    portfolio.open_position = Some(open_position.clone());
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::required("1h", 0)]),
+        portfolio,
+        0,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&calls),
+            [StrategyDecision::close_long()],
+        ),
+    );
+
+    runtime
+        .on_market_input(MarketInput::CompletedCandle(stale_secondary.clone()))
+        .unwrap();
+    let step = runtime
+        .on_market_input(MarketInput::CompletedCandle(primary.clone()))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 0);
+    assert_eq!(runtime.market_history("1h"), Some(&[stale_secondary][..]));
+    assert!(step.events.contains(&RuntimeEvent::RiskExitTriggered {
+        risk_exit: RiskExitTriggered {
+            side: PositionSide::Long,
+            selected: RiskExitKind::StopLoss,
+            triggered: vec![RiskExitKind::StopLoss],
+            exit_price: 90.0,
+        },
+    }));
+    assert_eq!(step.portfolio_snapshot.open_position, None);
+    assert_eq!(step.portfolio_snapshot.realized_cash_balance, 980.0);
+    assert!(step.events.iter().all(|event| !matches!(
+        event,
+        RuntimeEvent::StrategyTickBlocked { .. }
+            | RuntimeEvent::StrategyTickStarted { .. }
+            | RuntimeEvent::StrategyDecisionProduced { .. }
+            | RuntimeEvent::StrategyTickCompleted
+    )));
+}
+
+#[test]
+fn short_risk_exit_closes_before_stale_required_secondary_can_block_strategy_tick() {
+    let stale_secondary = candle(0, "1h", 100.0);
+    let primary = ohlc_candle(3_600_001, "1m", 100.0, 105.0, 80.0, 90.0);
+    let open_position = position_with_entry_risk(PositionSide::Short, 100.0, None, Some(80.0));
+    let calls = Rc::new(RefCell::new(0));
+    let mut portfolio = PortfolioState::new(1_000.0);
+    portfolio.open_position = Some(open_position.clone());
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::required("1h", 0)]),
+        portfolio,
+        0,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&calls),
+            [StrategyDecision::close_short()],
+        ),
+    );
+
+    runtime
+        .on_market_input(MarketInput::CompletedCandle(stale_secondary.clone()))
+        .unwrap();
+    let step = runtime
+        .on_market_input(MarketInput::CompletedCandle(primary.clone()))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 0);
+    assert_eq!(runtime.market_history("1h"), Some(&[stale_secondary][..]));
+    assert!(step.events.contains(&RuntimeEvent::RiskExitTriggered {
+        risk_exit: RiskExitTriggered {
+            side: PositionSide::Short,
+            selected: RiskExitKind::TakeProfit,
+            triggered: vec![RiskExitKind::TakeProfit],
+            exit_price: 80.0,
+        },
+    }));
+    assert_eq!(step.portfolio_snapshot.open_position, None);
+    assert_eq!(step.portfolio_snapshot.realized_cash_balance, 1_040.0);
+    assert!(step.events.iter().all(|event| !matches!(
+        event,
+        RuntimeEvent::StrategyTickBlocked { .. }
+            | RuntimeEvent::StrategyTickStarted { .. }
+            | RuntimeEvent::StrategyDecisionProduced { .. }
+            | RuntimeEvent::StrategyTickCompleted
+    )));
+}
+
+#[test]
+fn open_position_without_risk_exit_keeps_missing_required_secondary_as_strategy_only_blocker() {
+    let primary = ohlc_candle(60_000, "1m", 100.0, 105.0, 95.0, 101.0);
+    let open_position = position_with_entry_risk(PositionSide::Long, 100.0, Some(90.0), None);
+    let calls = Rc::new(RefCell::new(0));
+    let mut portfolio = PortfolioState::new(1_000.0);
+    portfolio.open_position = Some(open_position.clone());
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::required("1h", 0)]),
+        portfolio,
+        0,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&calls),
+            [StrategyDecision::close_long()],
+        ),
+    );
+
+    let step = runtime
+        .on_market_input(MarketInput::CompletedCandle(primary.clone()))
+        .unwrap();
+
+    let expected_snapshot = RuntimePortfolioSnapshot {
+        realized_cash_balance: 1_000.0,
+        open_position: Some(open_position),
+        completed_trade_count: 0,
+        current_equity: 1_002.0,
+    };
+    assert_eq!(*calls.borrow(), 0);
+    assert_eq!(
+        step.events,
+        vec![
+            RuntimeEvent::MarketInputAccepted {
+                candle: primary.clone(),
+            },
+            RuntimeEvent::TradableCandleAccepted {
+                candle: primary.clone(),
+            },
+            RuntimeEvent::StrategyTickBlocked {
+                candle: primary.clone(),
+                reason: StrategyTickBlockedReason::RequiredSecondaryUnavailable {
+                    timeframe: "1h".into(),
+                },
+            },
+            RuntimeEvent::TradableCandleCompleted,
+        ]
+    );
+    assert_eq!(step.portfolio_snapshot, expected_snapshot);
+    assert!(step.events.iter().all(|event| !matches!(
+        event,
+        RuntimeEvent::RiskExitTriggered { .. }
+            | RuntimeEvent::StrategyTickStarted { .. }
+            | RuntimeEvent::StrategyDecisionProduced { .. }
+            | RuntimeEvent::ExecutionActionPlanned { .. }
+            | RuntimeEvent::PositionClosed { .. }
     )));
 }
 

--- a/trading-runtime/tests/market_input.rs
+++ b/trading-runtime/tests/market_input.rs
@@ -82,7 +82,7 @@ impl StrategyHandler for CountingStrategyHandler {
 }
 
 #[test]
-fn completed_primary_market_input_routes_to_existing_tradable_candle_behavior() {
+fn completed_primary_market_input_emits_tradable_candle_and_strategy_tick_events() {
     let primary = candle(1, "1m", 100.0);
     let decision = StrategyDecision::open_long(2.0);
     let calls = Rc::new(RefCell::new(0));
@@ -106,7 +106,10 @@ fn completed_primary_market_input_routes_to_existing_tradable_candle_behavior() 
             RuntimeEvent::MarketInputAccepted {
                 candle: primary.clone(),
             },
-            RuntimeEvent::TradableTickStarted {
+            RuntimeEvent::TradableCandleAccepted {
+                candle: primary.clone(),
+            },
+            RuntimeEvent::StrategyTickStarted {
                 candle: primary.clone(),
             },
             RuntimeEvent::StrategyDecisionProduced { decision },
@@ -123,7 +126,8 @@ fn completed_primary_market_input_routes_to_existing_tradable_candle_behavior() 
             RuntimeEvent::PortfolioUpdated {
                 snapshot: step.portfolio_snapshot.clone(),
             },
-            RuntimeEvent::TradableTickCompleted,
+            RuntimeEvent::StrategyTickCompleted,
+            RuntimeEvent::TradableCandleCompleted,
         ]
     );
     assert!(step.portfolio_snapshot.open_position.is_some());
@@ -311,7 +315,7 @@ fn interleaved_completed_primary_and_secondary_inputs_only_evaluate_primary_inpu
     );
     assert!(!first_secondary_step.events.iter().any(|event| matches!(
         event,
-        RuntimeEvent::TradableTickStarted { .. }
+        RuntimeEvent::TradableCandleAccepted { .. }
             | RuntimeEvent::StrategyDecisionProduced { .. }
             | RuntimeEvent::ExecutionActionPlanned { .. }
             | RuntimeEvent::PositionOpened { .. }
@@ -320,7 +324,7 @@ fn interleaved_completed_primary_and_secondary_inputs_only_evaluate_primary_inpu
     )));
     assert!(!second_secondary_step.events.iter().any(|event| matches!(
         event,
-        RuntimeEvent::TradableTickStarted { .. }
+        RuntimeEvent::TradableCandleAccepted { .. }
             | RuntimeEvent::StrategyDecisionProduced { .. }
             | RuntimeEvent::ExecutionActionPlanned { .. }
             | RuntimeEvent::PositionOpened { .. }
@@ -505,7 +509,7 @@ fn completed_primary_before_all_timeframe_warmups_are_satisfied_is_stored_withou
     assert_eq!(early_step.portfolio_snapshot.completed_trade_count, 0);
     assert!(!early_step.events.iter().any(|event| matches!(
         event,
-        RuntimeEvent::TradableTickStarted { .. }
+        RuntimeEvent::TradableCandleAccepted { .. }
             | RuntimeEvent::StrategyDecisionProduced { .. }
             | RuntimeEvent::RiskExitTriggered { .. }
             | RuntimeEvent::PositionClosed { .. }

--- a/trading-runtime/tests/market_input.rs
+++ b/trading-runtime/tests/market_input.rs
@@ -264,6 +264,156 @@ fn completed_secondary_market_input_is_accepted_without_strategy_or_portfolio_tr
 }
 
 #[test]
+fn interleaved_completed_primary_and_secondary_inputs_only_evaluate_primary_inputs() {
+    let first_secondary = candle(1, "1h", 100.0);
+    let first_primary = candle(2, "1m", 101.0);
+    let second_secondary = candle(3, "1h", 102.0);
+    let second_primary = candle(4, "1m", 103.0);
+    let calls = Rc::new(RefCell::new(0));
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config(),
+        PortfolioState::new(1_000.0),
+        0,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&calls),
+            [
+                StrategyDecision::open_long(2.0),
+                StrategyDecision::close_long(),
+            ],
+        ),
+    );
+
+    let first_secondary_step = runtime
+        .on_market_input(MarketInput::CompletedCandle(first_secondary.clone()))
+        .unwrap();
+    let first_primary_step = runtime
+        .on_market_input(MarketInput::CompletedCandle(first_primary.clone()))
+        .unwrap();
+    let second_secondary_step = runtime
+        .on_market_input(MarketInput::CompletedCandle(second_secondary.clone()))
+        .unwrap();
+    let second_primary_step = runtime
+        .on_market_input(MarketInput::CompletedCandle(second_primary.clone()))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 2);
+    assert_eq!(
+        first_secondary_step.events,
+        vec![RuntimeEvent::MarketInputAccepted {
+            candle: first_secondary.clone(),
+        }]
+    );
+    assert_eq!(
+        second_secondary_step.events,
+        vec![RuntimeEvent::MarketInputAccepted {
+            candle: second_secondary.clone(),
+        }]
+    );
+    assert!(!first_secondary_step.events.iter().any(|event| matches!(
+        event,
+        RuntimeEvent::TradableTickStarted { .. }
+            | RuntimeEvent::StrategyDecisionProduced { .. }
+            | RuntimeEvent::ExecutionActionPlanned { .. }
+            | RuntimeEvent::PositionOpened { .. }
+            | RuntimeEvent::PositionClosed { .. }
+            | RuntimeEvent::PortfolioUpdated { .. }
+    )));
+    assert!(!second_secondary_step.events.iter().any(|event| matches!(
+        event,
+        RuntimeEvent::TradableTickStarted { .. }
+            | RuntimeEvent::StrategyDecisionProduced { .. }
+            | RuntimeEvent::ExecutionActionPlanned { .. }
+            | RuntimeEvent::PositionOpened { .. }
+            | RuntimeEvent::PositionClosed { .. }
+            | RuntimeEvent::PortfolioUpdated { .. }
+    )));
+    assert!(first_primary_step
+        .events
+        .iter()
+        .any(|event| matches!(event, RuntimeEvent::StrategyDecisionProduced { .. })));
+    assert!(second_primary_step
+        .events
+        .iter()
+        .any(|event| matches!(event, RuntimeEvent::StrategyDecisionProduced { .. })));
+    assert!(second_primary_step
+        .portfolio_snapshot
+        .open_position
+        .is_none());
+    assert_eq!(
+        second_primary_step.portfolio_snapshot.completed_trade_count,
+        1
+    );
+    assert_eq!(
+        runtime.market_history("1m"),
+        Some(&[first_primary, second_primary][..])
+    );
+    assert_eq!(
+        runtime.market_history("1h"),
+        Some(&[first_secondary, second_secondary][..])
+    );
+}
+
+#[test]
+fn completed_secondary_candle_that_crosses_entry_risk_does_not_trigger_risk_exit() {
+    let secondary_crossing_stop = ohlc_candle(1, "1h", 100.0, 101.0, 85.0, 88.0);
+    let primary_crossing_stop = ohlc_candle(2, "1m", 100.0, 101.0, 85.0, 88.0);
+    let calls = Rc::new(RefCell::new(0));
+    let mut portfolio = PortfolioState::new(1_000.0);
+    let open_position =
+        position_with_entry_risk(PositionSide::Long, 100.0, Some(90.0), Some(120.0));
+    portfolio.open_position = Some(open_position.clone());
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config(),
+        portfolio,
+        0,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&calls),
+            [StrategyDecision::close_long()],
+        ),
+    );
+
+    let secondary_step = runtime
+        .on_market_input(MarketInput::CompletedCandle(
+            secondary_crossing_stop.clone(),
+        ))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 0);
+    assert_eq!(
+        secondary_step.events,
+        vec![RuntimeEvent::MarketInputAccepted {
+            candle: secondary_crossing_stop.clone(),
+        }]
+    );
+    assert_eq!(
+        secondary_step.portfolio_snapshot.open_position,
+        Some(open_position)
+    );
+    assert_eq!(secondary_step.portfolio_snapshot.completed_trade_count, 0);
+    assert_eq!(runtime.market_history("1m"), Some(&[][..]));
+    assert_eq!(
+        runtime.market_history("1h"),
+        Some(&[secondary_crossing_stop][..])
+    );
+
+    let primary_step = runtime
+        .on_market_input(MarketInput::CompletedCandle(primary_crossing_stop.clone()))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 0);
+    assert!(primary_step
+        .events
+        .iter()
+        .any(|event| matches!(event, RuntimeEvent::RiskExitTriggered { .. })));
+    assert!(primary_step.portfolio_snapshot.open_position.is_none());
+    assert_eq!(primary_step.portfolio_snapshot.completed_trade_count, 1);
+    assert_eq!(
+        runtime.market_history("1m"),
+        Some(&[primary_crossing_stop][..])
+    );
+}
+
+#[test]
 fn multi_timeframe_warmup_does_not_complete_when_primary_is_ready_but_secondary_is_not() {
     let first_primary = candle(1, "1m", 100.0);
     let second_primary = candle(2, "1m", 101.0);

--- a/trading-runtime/tests/market_input.rs
+++ b/trading-runtime/tests/market_input.rs
@@ -1,4 +1,4 @@
-use shared::Candle;
+use shared::{Candle, Position, PositionSide};
 use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 use trading_runtime::{
     ExecutionAction, MarketInput, PortfolioState, RuntimeConfig, RuntimeEvent, RuntimeInputError,
@@ -6,15 +6,43 @@ use trading_runtime::{
 };
 
 fn candle(timestamp: i64, timeframe: &str, close: f64) -> Candle {
+    ohlc_candle(timestamp, timeframe, close, close, close, close)
+}
+
+fn ohlc_candle(
+    timestamp: i64,
+    timeframe: &str,
+    open: f64,
+    high: f64,
+    low: f64,
+    close: f64,
+) -> Candle {
     Candle {
         timestamp,
         symbol: "BTC-USD".into(),
-        open: close,
-        high: close,
-        low: close,
+        open,
+        high,
+        low,
         close,
         volume: 1_000.0,
         timeframe: timeframe.into(),
+    }
+}
+
+fn position_with_entry_risk(
+    side: PositionSide,
+    entry_price: f64,
+    stop_loss: Option<f64>,
+    take_profit: Option<f64>,
+) -> Position {
+    Position {
+        symbol: "BTC-USD".into(),
+        side,
+        entry_price,
+        size: 2.0,
+        entry_time: 0,
+        stop_loss,
+        take_profit,
     }
 }
 
@@ -70,6 +98,8 @@ fn completed_primary_market_input_routes_to_existing_tradable_candle_behavior() 
         .unwrap();
 
     assert_eq!(*calls.borrow(), 1);
+    assert_eq!(runtime.market_history("1m"), Some(&[primary.clone()][..]));
+    assert_eq!(runtime.market_history("1h"), Some(&[][..]));
     assert_eq!(
         step.events,
         vec![
@@ -119,6 +149,11 @@ fn warmup_primary_market_input_routes_to_existing_warmup_behavior() {
 
     assert_eq!(*calls.borrow(), 0);
     assert_eq!(
+        runtime.market_history("1m"),
+        Some(&[primary_warmup.clone()][..])
+    );
+    assert_eq!(runtime.market_history("1h"), Some(&[][..]));
+    assert_eq!(
         step.events,
         vec![
             RuntimeEvent::WarmupInputAccepted {
@@ -155,6 +190,11 @@ fn warmup_secondary_market_input_is_accepted_without_strategy_or_portfolio_trans
         .unwrap();
 
     assert_eq!(*calls.borrow(), 0);
+    assert_eq!(runtime.market_history("1m"), Some(&[][..]));
+    assert_eq!(
+        runtime.market_history("1h"),
+        Some(&[secondary_warmup.clone()][..])
+    );
     assert_eq!(
         step.events,
         vec![
@@ -196,6 +236,8 @@ fn completed_secondary_market_input_is_accepted_without_strategy_or_portfolio_tr
             candle: secondary.clone(),
         }]
     );
+    assert_eq!(runtime.market_history("1m"), Some(&[][..]));
+    assert_eq!(runtime.market_history("1h"), Some(&[secondary.clone()][..]));
     assert_eq!(*calls.borrow(), 0);
     assert_eq!(
         secondary_step.portfolio_snapshot,
@@ -203,10 +245,12 @@ fn completed_secondary_market_input_is_accepted_without_strategy_or_portfolio_tr
     );
 
     let primary_step = runtime
-        .on_market_input(MarketInput::CompletedCandle(primary))
+        .on_market_input(MarketInput::CompletedCandle(primary.clone()))
         .unwrap();
 
     assert_eq!(*calls.borrow(), 1);
+    assert_eq!(runtime.market_history("1m"), Some(&[primary][..]));
+    assert_eq!(runtime.market_history("1h"), Some(&[secondary][..]));
     assert_eq!(
         primary_step
             .portfolio_snapshot
@@ -234,6 +278,8 @@ fn unknown_timeframe_returns_input_error_without_consuming_strategy_decisions() 
         .on_market_input(MarketInput::CompletedCandle(unknown))
         .unwrap_err();
 
+    assert_eq!(runtime.market_history("1m"), Some(&[][..]));
+    assert_eq!(runtime.market_history("1h"), Some(&[][..]));
     assert_eq!(
         error,
         RuntimeInputError::UnknownTimeframe {
@@ -243,10 +289,11 @@ fn unknown_timeframe_returns_input_error_without_consuming_strategy_decisions() 
     assert_eq!(*calls.borrow(), 0);
 
     let primary_step = runtime
-        .on_market_input(MarketInput::CompletedCandle(primary))
+        .on_market_input(MarketInput::CompletedCandle(primary.clone()))
         .unwrap();
 
     assert_eq!(*calls.borrow(), 1);
+    assert_eq!(runtime.market_history("1m"), Some(&[primary][..]));
     assert!(primary_step.portfolio_snapshot.open_position.is_some());
 }
 
@@ -289,4 +336,78 @@ fn unknown_timeframe_returns_input_error_without_advancing_warmup() {
         .events
         .iter()
         .any(|event| matches!(event, RuntimeEvent::WarmupCompleted { .. })));
+}
+
+#[test]
+fn completed_primary_is_stored_even_when_risk_exit_prevents_strategy_tick() {
+    let exit_candle = ohlc_candle(2, "1m", 100.0, 105.0, 90.0, 99.0);
+    let calls = Rc::new(RefCell::new(0));
+    let mut portfolio = PortfolioState::new(1_000.0);
+    portfolio.open_position = Some(position_with_entry_risk(
+        PositionSide::Long,
+        100.0,
+        Some(90.0),
+        None,
+    ));
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config(),
+        portfolio,
+        0,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&calls),
+            [StrategyDecision::close_long()],
+        ),
+    );
+
+    let step = runtime
+        .on_market_input(MarketInput::CompletedCandle(exit_candle.clone()))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 0);
+    assert_eq!(runtime.market_history("1m"), Some(&[exit_candle][..]));
+    assert!(step
+        .events
+        .iter()
+        .any(|event| matches!(event, RuntimeEvent::RiskExitTriggered { .. })));
+    assert!(!step
+        .events
+        .iter()
+        .any(|event| matches!(event, RuntimeEvent::StrategyDecisionProduced { .. })));
+}
+
+#[test]
+fn unknown_timeframe_error_leaves_existing_market_state_histories_unchanged() {
+    let primary = candle(1, "1m", 100.0);
+    let secondary = candle(2, "1h", 101.0);
+    let unknown = candle(3, "5m", 102.0);
+    let calls = Rc::new(RefCell::new(0));
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config(),
+        PortfolioState::new(1_000.0),
+        0,
+        CountingStrategyHandler::from_decisions(Rc::clone(&calls), [StrategyDecision::hold()]),
+    );
+
+    runtime
+        .on_market_input(MarketInput::CompletedCandle(primary.clone()))
+        .unwrap();
+    runtime
+        .on_market_input(MarketInput::CompletedCandle(secondary.clone()))
+        .unwrap();
+    let primary_before = runtime.market_history("1m").unwrap().to_vec();
+    let secondary_before = runtime.market_history("1h").unwrap().to_vec();
+
+    let error = runtime
+        .on_market_input(MarketInput::CompletedCandle(unknown))
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        RuntimeInputError::UnknownTimeframe {
+            timeframe: "5m".into(),
+        }
+    );
+    assert_eq!(runtime.market_history("1m"), Some(&primary_before[..]));
+    assert_eq!(runtime.market_history("1h"), Some(&secondary_before[..]));
+    assert_eq!(runtime.market_history("5m"), None);
 }

--- a/trading-runtime/tests/market_input.rs
+++ b/trading-runtime/tests/market_input.rs
@@ -1,10 +1,11 @@
 use shared::{Candle, Position, PositionSide};
 use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 use trading_runtime::{
-    ClosedPosition, ExecutionAction, ExitKind, MarketInput, PortfolioState, RiskExitKind,
-    RiskExitTriggered, RuntimeConfig, RuntimeEvent, RuntimeInputError, RuntimePortfolioSnapshot,
-    SecondaryContextUnavailableReason, SecondaryReadiness, SecondaryTimeframeConfig,
-    StrategyDecision, StrategyHandler, StrategyTickBlockedReason, TradingRuntime,
+    BlockedSecondaryContext, ClosedPosition, ExecutionAction, ExitKind, MarketInput,
+    PortfolioState, RiskExitKind, RiskExitTriggered, RuntimeConfig, RuntimeEvent,
+    RuntimeInputError, RuntimePortfolioSnapshot, SecondaryContextUnavailableReason,
+    SecondaryReadiness, SecondaryTimeframeConfig, StrategyDecision, StrategyHandler,
+    TradingRuntime,
 };
 
 fn candle(timestamp: i64, timeframe: &str, close: f64) -> Candle {
@@ -49,7 +50,11 @@ fn position_with_entry_risk(
 }
 
 fn runtime_config() -> RuntimeConfig {
-    RuntimeConfig::new("BTC-USD", "1m", ["1h"])
+    RuntimeConfig::with_secondary_configs(
+        "BTC-USD",
+        "1m",
+        [SecondaryTimeframeConfig::optional("1h", 0)],
+    )
 }
 
 #[derive(Clone)]
@@ -773,9 +778,10 @@ fn required_secondary_missing_blocks_strategy_tick_after_storing_primary() {
             },
             RuntimeEvent::StrategyTickBlocked {
                 candle: primary.clone(),
-                reason: StrategyTickBlockedReason::RequiredSecondaryUnavailable {
+                blocked_contexts: vec![BlockedSecondaryContext {
                     timeframe: "1h".into(),
-                },
+                    reason: SecondaryContextUnavailableReason::Missing,
+                }],
             },
             RuntimeEvent::TradableCandleCompleted,
         ]
@@ -786,6 +792,46 @@ fn required_secondary_missing_blocks_strategy_tick_after_storing_primary() {
             | RuntimeEvent::StrategyDecisionProduced { .. }
             | RuntimeEvent::ExecutionActionPlanned { .. }
     )));
+}
+
+#[test]
+fn missing_required_secondaries_are_reported_together_when_strategy_tick_is_blocked() {
+    let primary = candle(60_000, "1m", 100.0);
+    let calls = Rc::new(RefCell::new(0));
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config_with_secondary_configs(
+            "1m",
+            [
+                SecondaryTimeframeConfig::required("1h", 0),
+                SecondaryTimeframeConfig::required("1d", 0),
+            ],
+        ),
+        PortfolioState::new(1_000.0),
+        0,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&calls),
+            [StrategyDecision::open_long(2.0)],
+        ),
+    );
+
+    let step = runtime
+        .on_market_input(MarketInput::CompletedCandle(primary.clone()))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 0);
+    assert!(step.events.contains(&RuntimeEvent::StrategyTickBlocked {
+        candle: primary,
+        blocked_contexts: vec![
+            BlockedSecondaryContext {
+                timeframe: "1h".into(),
+                reason: SecondaryContextUnavailableReason::Missing,
+            },
+            BlockedSecondaryContext {
+                timeframe: "1d".into(),
+                reason: SecondaryContextUnavailableReason::Missing,
+            },
+        ],
+    }));
 }
 
 #[test]
@@ -1083,9 +1129,10 @@ fn open_position_without_risk_exit_keeps_missing_required_secondary_as_strategy_
             },
             RuntimeEvent::StrategyTickBlocked {
                 candle: primary.clone(),
-                reason: StrategyTickBlockedReason::RequiredSecondaryUnavailable {
+                blocked_contexts: vec![BlockedSecondaryContext {
                     timeframe: "1h".into(),
-                },
+                    reason: SecondaryContextUnavailableReason::Missing,
+                }],
             },
             RuntimeEvent::TradableCandleCompleted,
         ]
@@ -1143,9 +1190,10 @@ fn coarse_required_secondary_remains_fresh_until_duration_and_tolerance_are_exce
             },
             RuntimeEvent::StrategyTickBlocked {
                 candle: stale_primary.clone(),
-                reason: StrategyTickBlockedReason::RequiredSecondaryStale {
+                blocked_contexts: vec![BlockedSecondaryContext {
                     timeframe: "1h".into(),
-                },
+                    reason: SecondaryContextUnavailableReason::Stale,
+                }],
             },
             RuntimeEvent::TradableCandleCompleted,
         ]
@@ -1293,9 +1341,10 @@ fn fine_secondary_freshness_uses_secondary_duration_not_primary_duration() {
             },
             RuntimeEvent::StrategyTickBlocked {
                 candle: primary.clone(),
-                reason: StrategyTickBlockedReason::RequiredSecondaryStale {
+                blocked_contexts: vec![BlockedSecondaryContext {
                     timeframe: "1m".into(),
-                },
+                    reason: SecondaryContextUnavailableReason::Stale,
+                }],
             },
             RuntimeEvent::TradableCandleCompleted,
         ]

--- a/trading-runtime/tests/market_input.rs
+++ b/trading-runtime/tests/market_input.rs
@@ -160,6 +160,7 @@ fn warmup_primary_market_input_routes_to_existing_warmup_behavior() {
                 candle: primary_warmup.clone(),
             },
             RuntimeEvent::WarmupAdvanced {
+                timeframe: "1m".into(),
                 current_warmup_input_count: 1,
                 required_warmup_inputs: 2,
             },
@@ -202,6 +203,7 @@ fn warmup_secondary_market_input_is_accepted_without_strategy_or_portfolio_trans
                 candle: secondary_warmup.clone(),
             },
             RuntimeEvent::WarmupAdvanced {
+                timeframe: "1h".into(),
                 current_warmup_input_count: 1,
                 required_warmup_inputs: 2,
             },
@@ -258,6 +260,163 @@ fn completed_secondary_market_input_is_accepted_without_strategy_or_portfolio_tr
             .as_ref()
             .map(|position| position.size),
         Some(2.0)
+    );
+}
+
+#[test]
+fn multi_timeframe_warmup_does_not_complete_when_primary_is_ready_but_secondary_is_not() {
+    let first_primary = candle(1, "1m", 100.0);
+    let second_primary = candle(2, "1m", 101.0);
+    let calls = Rc::new(RefCell::new(0));
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config(),
+        PortfolioState::new(1_000.0),
+        2,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&calls),
+            [StrategyDecision::open_long(2.0)],
+        ),
+    );
+
+    runtime
+        .on_market_input(MarketInput::WarmupCandle(first_primary.clone()))
+        .unwrap();
+    let second_step = runtime
+        .on_market_input(MarketInput::WarmupCandle(second_primary.clone()))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 0);
+    assert_eq!(
+        runtime.market_history("1m"),
+        Some(&[first_primary, second_primary][..])
+    );
+    assert_eq!(runtime.market_history("1h"), Some(&[][..]));
+    assert!(!second_step
+        .events
+        .iter()
+        .any(|event| matches!(event, RuntimeEvent::WarmupCompleted { .. })));
+}
+
+#[test]
+fn completed_primary_before_all_timeframe_warmups_are_satisfied_is_stored_without_trading() {
+    let primary_warmup_1 = candle(1, "1m", 100.0);
+    let primary_warmup_2 = candle(2, "1m", 101.0);
+    let early_completed_primary = ohlc_candle(3, "1m", 100.0, 105.0, 90.0, 99.0);
+    let calls = Rc::new(RefCell::new(0));
+    let mut portfolio = PortfolioState::new(1_000.0);
+    portfolio.open_position = Some(position_with_entry_risk(
+        PositionSide::Long,
+        100.0,
+        Some(90.0),
+        None,
+    ));
+    let open_position = portfolio.open_position.clone();
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config(),
+        portfolio,
+        2,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&calls),
+            [StrategyDecision::close_long()],
+        ),
+    );
+
+    runtime
+        .on_market_input(MarketInput::WarmupCandle(primary_warmup_1.clone()))
+        .unwrap();
+    runtime
+        .on_market_input(MarketInput::WarmupCandle(primary_warmup_2.clone()))
+        .unwrap();
+    let early_step = runtime
+        .on_market_input(MarketInput::CompletedCandle(
+            early_completed_primary.clone(),
+        ))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 0);
+    assert_eq!(
+        runtime.market_history("1m"),
+        Some(
+            &[
+                primary_warmup_1,
+                primary_warmup_2,
+                early_completed_primary.clone()
+            ][..]
+        )
+    );
+    assert_eq!(runtime.market_history("1h"), Some(&[][..]));
+    assert_eq!(
+        early_step.events,
+        vec![RuntimeEvent::MarketInputAccepted {
+            candle: early_completed_primary.clone(),
+        }]
+    );
+    assert_eq!(early_step.portfolio_snapshot.open_position, open_position);
+    assert_eq!(early_step.portfolio_snapshot.completed_trade_count, 0);
+    assert!(!early_step.events.iter().any(|event| matches!(
+        event,
+        RuntimeEvent::TradableTickStarted { .. }
+            | RuntimeEvent::StrategyDecisionProduced { .. }
+            | RuntimeEvent::RiskExitTriggered { .. }
+            | RuntimeEvent::PositionClosed { .. }
+            | RuntimeEvent::PortfolioUpdated { .. }
+    )));
+}
+
+#[test]
+fn first_completed_primary_after_all_timeframe_warmups_are_satisfied_runs_strategy() {
+    let primary_warmup_1 = candle(1, "1m", 100.0);
+    let primary_warmup_2 = candle(2, "1m", 101.0);
+    let secondary_warmup_1 = candle(3, "1h", 100.0);
+    let secondary_warmup_2 = candle(4, "1h", 101.0);
+    let first_completed_primary = candle(5, "1m", 102.0);
+    let decision = StrategyDecision::open_long(2.0);
+    let calls = Rc::new(RefCell::new(0));
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config(),
+        PortfolioState::new(1_000.0),
+        2,
+        CountingStrategyHandler::from_decisions(Rc::clone(&calls), [decision]),
+    );
+
+    runtime
+        .on_market_input(MarketInput::WarmupCandle(primary_warmup_1.clone()))
+        .unwrap();
+    runtime
+        .on_market_input(MarketInput::WarmupCandle(primary_warmup_2.clone()))
+        .unwrap();
+    runtime
+        .on_market_input(MarketInput::WarmupCandle(secondary_warmup_1.clone()))
+        .unwrap();
+    let completion_step = runtime
+        .on_market_input(MarketInput::WarmupCandle(secondary_warmup_2.clone()))
+        .unwrap();
+
+    assert!(completion_step
+        .events
+        .iter()
+        .any(|event| matches!(event, RuntimeEvent::WarmupCompleted { .. })));
+    assert_eq!(*calls.borrow(), 0);
+
+    let active_step = runtime
+        .on_market_input(MarketInput::CompletedCandle(
+            first_completed_primary.clone(),
+        ))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 1);
+    assert!(active_step
+        .events
+        .iter()
+        .any(|event| matches!(event, RuntimeEvent::StrategyDecisionProduced { .. })));
+    assert!(active_step.portfolio_snapshot.open_position.is_some());
+    assert_eq!(
+        runtime.market_history("1m"),
+        Some(&[primary_warmup_1, primary_warmup_2, first_completed_primary][..])
+    );
+    assert_eq!(
+        runtime.market_history("1h"),
+        Some(&[secondary_warmup_1, secondary_warmup_2][..])
     );
 }
 
@@ -329,6 +488,7 @@ fn unknown_timeframe_returns_input_error_without_advancing_warmup() {
 
     assert_eq!(*calls.borrow(), 0);
     assert!(warmup_step.events.contains(&RuntimeEvent::WarmupAdvanced {
+        timeframe: "1m".into(),
         current_warmup_input_count: 1,
         required_warmup_inputs: 2,
     }));

--- a/trading-runtime/tests/market_input.rs
+++ b/trading-runtime/tests/market_input.rs
@@ -4,9 +4,13 @@ use trading_runtime::{
     BlockedSecondaryContext, ClosedPosition, ExecutionAction, ExitKind, MarketInput,
     PortfolioState, RiskExitKind, RiskExitTriggered, RuntimeConfig, RuntimeEvent,
     RuntimeInputError, RuntimePortfolioSnapshot, SecondaryContextUnavailableReason,
-    SecondaryReadiness, SecondaryTimeframeConfig, StrategyDecision, StrategyHandler,
+    SecondaryReadiness, SecondaryTimeframeConfig, StrategyDecision, StrategyHandler, Timeframe,
     TradingRuntime,
 };
+
+fn tf(raw: &str) -> Timeframe {
+    raw.parse().expect("test timeframe should be valid")
+}
 
 fn candle(timestamp: i64, timeframe: &str, close: f64) -> Candle {
     ohlc_candle(timestamp, timeframe, close, close, close, close)
@@ -28,7 +32,7 @@ fn ohlc_candle(
         low,
         close,
         volume: 1_000.0,
-        timeframe: timeframe.into(),
+        timeframe: tf(timeframe),
     }
 }
 
@@ -52,8 +56,8 @@ fn position_with_entry_risk(
 fn runtime_config() -> RuntimeConfig {
     RuntimeConfig::with_secondary_configs(
         "BTC-USD",
-        "1m",
-        [SecondaryTimeframeConfig::optional("1h", 0)],
+        tf("1m"),
+        [SecondaryTimeframeConfig::optional(tf("1h"), 0)],
     )
 }
 
@@ -105,8 +109,11 @@ fn completed_primary_market_input_emits_tradable_candle_and_strategy_tick_events
         .unwrap();
 
     assert_eq!(*calls.borrow(), 1);
-    assert_eq!(runtime.market_history("1m"), Some(&[primary.clone()][..]));
-    assert_eq!(runtime.market_history("1h"), Some(&[][..]));
+    assert_eq!(
+        runtime.market_history(tf("1m")),
+        Some(&[primary.clone()][..])
+    );
+    assert_eq!(runtime.market_history(tf("1h")), Some(&[][..]));
     assert_eq!(
         step.events,
         vec![
@@ -118,7 +125,7 @@ fn completed_primary_market_input_emits_tradable_candle_and_strategy_tick_events
             },
             RuntimeEvent::SecondaryContextUnavailable {
                 candle: primary.clone(),
-                timeframe: "1h".into(),
+                timeframe: tf("1h"),
                 readiness: SecondaryReadiness::Optional,
                 reason: SecondaryContextUnavailableReason::Missing,
             },
@@ -166,10 +173,10 @@ fn warmup_primary_market_input_routes_to_existing_warmup_behavior() {
 
     assert_eq!(*calls.borrow(), 0);
     assert_eq!(
-        runtime.market_history("1m"),
+        runtime.market_history(tf("1m")),
         Some(&[primary_warmup.clone()][..])
     );
-    assert_eq!(runtime.market_history("1h"), Some(&[][..]));
+    assert_eq!(runtime.market_history(tf("1h")), Some(&[][..]));
     assert_eq!(
         step.events,
         vec![
@@ -177,7 +184,7 @@ fn warmup_primary_market_input_routes_to_existing_warmup_behavior() {
                 candle: primary_warmup.clone(),
             },
             RuntimeEvent::WarmupAdvanced {
-                timeframe: "1m".into(),
+                timeframe: tf("1m"),
                 current_warmup_input_count: 1,
                 required_warmup_inputs: 2,
             },
@@ -208,9 +215,9 @@ fn warmup_secondary_market_input_is_accepted_without_strategy_or_portfolio_trans
         .unwrap();
 
     assert_eq!(*calls.borrow(), 0);
-    assert_eq!(runtime.market_history("1m"), Some(&[][..]));
+    assert_eq!(runtime.market_history(tf("1m")), Some(&[][..]));
     assert_eq!(
-        runtime.market_history("1h"),
+        runtime.market_history(tf("1h")),
         Some(&[secondary_warmup.clone()][..])
     );
     assert_eq!(
@@ -220,7 +227,7 @@ fn warmup_secondary_market_input_is_accepted_without_strategy_or_portfolio_trans
                 candle: secondary_warmup.clone(),
             },
             RuntimeEvent::WarmupAdvanced {
-                timeframe: "1h".into(),
+                timeframe: tf("1h"),
                 current_warmup_input_count: 1,
                 required_warmup_inputs: 2,
             },
@@ -255,8 +262,11 @@ fn completed_secondary_market_input_is_accepted_without_strategy_or_portfolio_tr
             candle: secondary.clone(),
         }]
     );
-    assert_eq!(runtime.market_history("1m"), Some(&[][..]));
-    assert_eq!(runtime.market_history("1h"), Some(&[secondary.clone()][..]));
+    assert_eq!(runtime.market_history(tf("1m")), Some(&[][..]));
+    assert_eq!(
+        runtime.market_history(tf("1h")),
+        Some(&[secondary.clone()][..])
+    );
     assert_eq!(*calls.borrow(), 0);
     assert_eq!(
         secondary_step.portfolio_snapshot,
@@ -268,8 +278,8 @@ fn completed_secondary_market_input_is_accepted_without_strategy_or_portfolio_tr
         .unwrap();
 
     assert_eq!(*calls.borrow(), 1);
-    assert_eq!(runtime.market_history("1m"), Some(&[primary][..]));
-    assert_eq!(runtime.market_history("1h"), Some(&[secondary][..]));
+    assert_eq!(runtime.market_history(tf("1m")), Some(&[primary][..]));
+    assert_eq!(runtime.market_history(tf("1h")), Some(&[secondary][..]));
     assert_eq!(
         primary_step
             .portfolio_snapshot
@@ -361,11 +371,11 @@ fn interleaved_completed_primary_and_secondary_inputs_only_evaluate_primary_inpu
         1
     );
     assert_eq!(
-        runtime.market_history("1m"),
+        runtime.market_history(tf("1m")),
         Some(&[first_primary, second_primary][..])
     );
     assert_eq!(
-        runtime.market_history("1h"),
+        runtime.market_history(tf("1h")),
         Some(&[first_secondary, second_secondary][..])
     );
 }
@@ -407,9 +417,9 @@ fn completed_secondary_candle_that_crosses_entry_risk_does_not_trigger_risk_exit
         Some(open_position)
     );
     assert_eq!(secondary_step.portfolio_snapshot.completed_trade_count, 0);
-    assert_eq!(runtime.market_history("1m"), Some(&[][..]));
+    assert_eq!(runtime.market_history(tf("1m")), Some(&[][..]));
     assert_eq!(
-        runtime.market_history("1h"),
+        runtime.market_history(tf("1h")),
         Some(&[secondary_crossing_stop][..])
     );
 
@@ -425,7 +435,7 @@ fn completed_secondary_candle_that_crosses_entry_risk_does_not_trigger_risk_exit
     assert!(primary_step.portfolio_snapshot.open_position.is_none());
     assert_eq!(primary_step.portfolio_snapshot.completed_trade_count, 1);
     assert_eq!(
-        runtime.market_history("1m"),
+        runtime.market_history(tf("1m")),
         Some(&[primary_crossing_stop][..])
     );
 }
@@ -454,10 +464,10 @@ fn multi_timeframe_warmup_does_not_complete_when_primary_is_ready_but_secondary_
 
     assert_eq!(*calls.borrow(), 0);
     assert_eq!(
-        runtime.market_history("1m"),
+        runtime.market_history(tf("1m")),
         Some(&[first_primary, second_primary][..])
     );
-    assert_eq!(runtime.market_history("1h"), Some(&[][..]));
+    assert_eq!(runtime.market_history(tf("1h")), Some(&[][..]));
     assert!(!second_step
         .events
         .iter()
@@ -502,7 +512,7 @@ fn completed_primary_before_all_timeframe_warmups_are_satisfied_is_stored_withou
 
     assert_eq!(*calls.borrow(), 0);
     assert_eq!(
-        runtime.market_history("1m"),
+        runtime.market_history(tf("1m")),
         Some(
             &[
                 primary_warmup_1,
@@ -511,7 +521,7 @@ fn completed_primary_before_all_timeframe_warmups_are_satisfied_is_stored_withou
             ][..]
         )
     );
-    assert_eq!(runtime.market_history("1h"), Some(&[][..]));
+    assert_eq!(runtime.market_history(tf("1h")), Some(&[][..]));
     assert_eq!(
         early_step.events,
         vec![RuntimeEvent::MarketInputAccepted {
@@ -578,11 +588,11 @@ fn first_completed_primary_after_all_timeframe_warmups_are_satisfied_runs_strate
         .any(|event| matches!(event, RuntimeEvent::StrategyDecisionProduced { .. })));
     assert!(active_step.portfolio_snapshot.open_position.is_some());
     assert_eq!(
-        runtime.market_history("1m"),
+        runtime.market_history(tf("1m")),
         Some(&[primary_warmup_1, primary_warmup_2, first_completed_primary][..])
     );
     assert_eq!(
-        runtime.market_history("1h"),
+        runtime.market_history(tf("1h")),
         Some(&[secondary_warmup_1, secondary_warmup_2][..])
     );
 }
@@ -604,12 +614,12 @@ fn unknown_timeframe_returns_input_error_without_consuming_strategy_decisions() 
         .on_market_input(MarketInput::CompletedCandle(unknown))
         .unwrap_err();
 
-    assert_eq!(runtime.market_history("1m"), Some(&[][..]));
-    assert_eq!(runtime.market_history("1h"), Some(&[][..]));
+    assert_eq!(runtime.market_history(tf("1m")), Some(&[][..]));
+    assert_eq!(runtime.market_history(tf("1h")), Some(&[][..]));
     assert_eq!(
         error,
         RuntimeInputError::UnknownTimeframe {
-            timeframe: "5m".into(),
+            timeframe: tf("5m"),
         }
     );
     assert_eq!(*calls.borrow(), 0);
@@ -619,7 +629,7 @@ fn unknown_timeframe_returns_input_error_without_consuming_strategy_decisions() 
         .unwrap();
 
     assert_eq!(*calls.borrow(), 1);
-    assert_eq!(runtime.market_history("1m"), Some(&[primary][..]));
+    assert_eq!(runtime.market_history(tf("1m")), Some(&[primary][..]));
     assert!(primary_step.portfolio_snapshot.open_position.is_some());
 }
 
@@ -645,7 +655,7 @@ fn unknown_timeframe_returns_input_error_without_advancing_warmup() {
     assert_eq!(
         error,
         RuntimeInputError::UnknownTimeframe {
-            timeframe: "5m".into(),
+            timeframe: tf("5m"),
         }
     );
 
@@ -655,7 +665,7 @@ fn unknown_timeframe_returns_input_error_without_advancing_warmup() {
 
     assert_eq!(*calls.borrow(), 0);
     assert!(warmup_step.events.contains(&RuntimeEvent::WarmupAdvanced {
-        timeframe: "1m".into(),
+        timeframe: tf("1m"),
         current_warmup_input_count: 1,
         required_warmup_inputs: 2,
     }));
@@ -691,7 +701,7 @@ fn completed_primary_is_stored_even_when_risk_exit_prevents_strategy_tick() {
         .unwrap();
 
     assert_eq!(*calls.borrow(), 0);
-    assert_eq!(runtime.market_history("1m"), Some(&[exit_candle][..]));
+    assert_eq!(runtime.market_history(tf("1m")), Some(&[exit_candle][..]));
     assert!(step
         .events
         .iter()
@@ -721,8 +731,8 @@ fn unknown_timeframe_error_leaves_existing_market_state_histories_unchanged() {
     runtime
         .on_market_input(MarketInput::CompletedCandle(secondary.clone()))
         .unwrap();
-    let primary_before = runtime.market_history("1m").unwrap().to_vec();
-    let secondary_before = runtime.market_history("1h").unwrap().to_vec();
+    let primary_before = runtime.market_history(tf("1m")).unwrap().to_vec();
+    let secondary_before = runtime.market_history(tf("1h")).unwrap().to_vec();
 
     let error = runtime
         .on_market_input(MarketInput::CompletedCandle(unknown))
@@ -731,19 +741,22 @@ fn unknown_timeframe_error_leaves_existing_market_state_histories_unchanged() {
     assert_eq!(
         error,
         RuntimeInputError::UnknownTimeframe {
-            timeframe: "5m".into(),
+            timeframe: tf("5m"),
         }
     );
-    assert_eq!(runtime.market_history("1m"), Some(&primary_before[..]));
-    assert_eq!(runtime.market_history("1h"), Some(&secondary_before[..]));
-    assert_eq!(runtime.market_history("5m"), None);
+    assert_eq!(runtime.market_history(tf("1m")), Some(&primary_before[..]));
+    assert_eq!(
+        runtime.market_history(tf("1h")),
+        Some(&secondary_before[..])
+    );
+    assert_eq!(runtime.market_history(tf("5m")), None);
 }
 
 fn runtime_config_with_secondary_configs(
     primary_timeframe: &str,
     secondary_timeframes: impl IntoIterator<Item = SecondaryTimeframeConfig>,
 ) -> RuntimeConfig {
-    RuntimeConfig::with_secondary_configs("BTC-USD", primary_timeframe, secondary_timeframes)
+    RuntimeConfig::with_secondary_configs("BTC-USD", tf(primary_timeframe), secondary_timeframes)
 }
 
 #[test]
@@ -751,7 +764,10 @@ fn required_secondary_missing_blocks_strategy_tick_after_storing_primary() {
     let primary = candle(60_000, "1m", 100.0);
     let calls = Rc::new(RefCell::new(0));
     let mut runtime = TradingRuntime::with_config(
-        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::required("1h", 0)]),
+        runtime_config_with_secondary_configs(
+            "1m",
+            [SecondaryTimeframeConfig::required(tf("1h"), 0)],
+        ),
         PortfolioState::new(1_000.0),
         0,
         CountingStrategyHandler::from_decisions(
@@ -765,8 +781,11 @@ fn required_secondary_missing_blocks_strategy_tick_after_storing_primary() {
         .unwrap();
 
     assert_eq!(*calls.borrow(), 0);
-    assert_eq!(runtime.market_history("1m"), Some(&[primary.clone()][..]));
-    assert_eq!(runtime.market_history("1h"), Some(&[][..]));
+    assert_eq!(
+        runtime.market_history(tf("1m")),
+        Some(&[primary.clone()][..])
+    );
+    assert_eq!(runtime.market_history(tf("1h")), Some(&[][..]));
     assert_eq!(
         step.events,
         vec![
@@ -779,7 +798,7 @@ fn required_secondary_missing_blocks_strategy_tick_after_storing_primary() {
             RuntimeEvent::StrategyTickBlocked {
                 candle: primary.clone(),
                 blocked_contexts: vec![BlockedSecondaryContext {
-                    timeframe: "1h".into(),
+                    timeframe: tf("1h"),
                     reason: SecondaryContextUnavailableReason::Missing,
                 }],
             },
@@ -802,8 +821,8 @@ fn missing_required_secondaries_are_reported_together_when_strategy_tick_is_bloc
         runtime_config_with_secondary_configs(
             "1m",
             [
-                SecondaryTimeframeConfig::required("1h", 0),
-                SecondaryTimeframeConfig::required("1d", 0),
+                SecondaryTimeframeConfig::required(tf("1h"), 0),
+                SecondaryTimeframeConfig::required(tf("1d"), 0),
             ],
         ),
         PortfolioState::new(1_000.0),
@@ -823,11 +842,11 @@ fn missing_required_secondaries_are_reported_together_when_strategy_tick_is_bloc
         candle: primary,
         blocked_contexts: vec![
             BlockedSecondaryContext {
-                timeframe: "1h".into(),
+                timeframe: tf("1h"),
                 reason: SecondaryContextUnavailableReason::Missing,
             },
             BlockedSecondaryContext {
-                timeframe: "1d".into(),
+                timeframe: tf("1d"),
                 reason: SecondaryContextUnavailableReason::Missing,
             },
         ],
@@ -842,7 +861,10 @@ fn long_risk_exit_closes_before_missing_required_secondary_can_block_strategy_ti
     let mut portfolio = PortfolioState::new(1_000.0);
     portfolio.open_position = Some(open_position.clone());
     let mut runtime = TradingRuntime::with_config(
-        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::required("1h", 0)]),
+        runtime_config_with_secondary_configs(
+            "1m",
+            [SecondaryTimeframeConfig::required(tf("1h"), 0)],
+        ),
         portfolio,
         0,
         CountingStrategyHandler::from_decisions(
@@ -868,8 +890,11 @@ fn long_risk_exit_closes_before_missing_required_secondary_can_block_strategy_ti
         current_equity: 980.0,
     };
     assert_eq!(*calls.borrow(), 0);
-    assert_eq!(runtime.market_history("1m"), Some(&[primary.clone()][..]));
-    assert_eq!(runtime.market_history("1h"), Some(&[][..]));
+    assert_eq!(
+        runtime.market_history(tf("1m")),
+        Some(&[primary.clone()][..])
+    );
+    assert_eq!(runtime.market_history(tf("1h")), Some(&[][..]));
     assert_eq!(
         step.events,
         vec![
@@ -924,7 +949,10 @@ fn short_risk_exit_closes_before_missing_required_secondary_can_block_strategy_t
     let mut portfolio = PortfolioState::new(1_000.0);
     portfolio.open_position = Some(open_position.clone());
     let mut runtime = TradingRuntime::with_config(
-        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::required("1h", 0)]),
+        runtime_config_with_secondary_configs(
+            "1m",
+            [SecondaryTimeframeConfig::required(tf("1h"), 0)],
+        ),
         portfolio,
         0,
         CountingStrategyHandler::from_decisions(
@@ -950,8 +978,11 @@ fn short_risk_exit_closes_before_missing_required_secondary_can_block_strategy_t
         current_equity: 1_040.0,
     };
     assert_eq!(*calls.borrow(), 0);
-    assert_eq!(runtime.market_history("1m"), Some(&[primary.clone()][..]));
-    assert_eq!(runtime.market_history("1h"), Some(&[][..]));
+    assert_eq!(
+        runtime.market_history(tf("1m")),
+        Some(&[primary.clone()][..])
+    );
+    assert_eq!(runtime.market_history(tf("1h")), Some(&[][..]));
     assert_eq!(
         step.events,
         vec![
@@ -1007,7 +1038,10 @@ fn long_risk_exit_closes_before_stale_required_secondary_can_block_strategy_tick
     let mut portfolio = PortfolioState::new(1_000.0);
     portfolio.open_position = Some(open_position.clone());
     let mut runtime = TradingRuntime::with_config(
-        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::required("1h", 0)]),
+        runtime_config_with_secondary_configs(
+            "1m",
+            [SecondaryTimeframeConfig::required(tf("1h"), 0)],
+        ),
         portfolio,
         0,
         CountingStrategyHandler::from_decisions(
@@ -1024,7 +1058,10 @@ fn long_risk_exit_closes_before_stale_required_secondary_can_block_strategy_tick
         .unwrap();
 
     assert_eq!(*calls.borrow(), 0);
-    assert_eq!(runtime.market_history("1h"), Some(&[stale_secondary][..]));
+    assert_eq!(
+        runtime.market_history(tf("1h")),
+        Some(&[stale_secondary][..])
+    );
     assert!(step.events.contains(&RuntimeEvent::RiskExitTriggered {
         risk_exit: RiskExitTriggered {
             side: PositionSide::Long,
@@ -1053,7 +1090,10 @@ fn short_risk_exit_closes_before_stale_required_secondary_can_block_strategy_tic
     let mut portfolio = PortfolioState::new(1_000.0);
     portfolio.open_position = Some(open_position.clone());
     let mut runtime = TradingRuntime::with_config(
-        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::required("1h", 0)]),
+        runtime_config_with_secondary_configs(
+            "1m",
+            [SecondaryTimeframeConfig::required(tf("1h"), 0)],
+        ),
         portfolio,
         0,
         CountingStrategyHandler::from_decisions(
@@ -1070,7 +1110,10 @@ fn short_risk_exit_closes_before_stale_required_secondary_can_block_strategy_tic
         .unwrap();
 
     assert_eq!(*calls.borrow(), 0);
-    assert_eq!(runtime.market_history("1h"), Some(&[stale_secondary][..]));
+    assert_eq!(
+        runtime.market_history(tf("1h")),
+        Some(&[stale_secondary][..])
+    );
     assert!(step.events.contains(&RuntimeEvent::RiskExitTriggered {
         risk_exit: RiskExitTriggered {
             side: PositionSide::Short,
@@ -1098,7 +1141,10 @@ fn open_position_without_risk_exit_keeps_missing_required_secondary_as_strategy_
     let mut portfolio = PortfolioState::new(1_000.0);
     portfolio.open_position = Some(open_position.clone());
     let mut runtime = TradingRuntime::with_config(
-        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::required("1h", 0)]),
+        runtime_config_with_secondary_configs(
+            "1m",
+            [SecondaryTimeframeConfig::required(tf("1h"), 0)],
+        ),
         portfolio,
         0,
         CountingStrategyHandler::from_decisions(
@@ -1130,7 +1176,7 @@ fn open_position_without_risk_exit_keeps_missing_required_secondary_as_strategy_
             RuntimeEvent::StrategyTickBlocked {
                 candle: primary.clone(),
                 blocked_contexts: vec![BlockedSecondaryContext {
-                    timeframe: "1h".into(),
+                    timeframe: tf("1h"),
                     reason: SecondaryContextUnavailableReason::Missing,
                 }],
             },
@@ -1155,7 +1201,10 @@ fn coarse_required_secondary_remains_fresh_until_duration_and_tolerance_are_exce
     let stale_primary = candle(7_200_001, "1m", 102.0);
     let calls = Rc::new(RefCell::new(0));
     let mut runtime = TradingRuntime::with_config(
-        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::required("1h", 1)]),
+        runtime_config_with_secondary_configs(
+            "1m",
+            [SecondaryTimeframeConfig::required(tf("1h"), 1)],
+        ),
         PortfolioState::new(1_000.0),
         0,
         CountingStrategyHandler::from_decisions(
@@ -1191,7 +1240,7 @@ fn coarse_required_secondary_remains_fresh_until_duration_and_tolerance_are_exce
             RuntimeEvent::StrategyTickBlocked {
                 candle: stale_primary.clone(),
                 blocked_contexts: vec![BlockedSecondaryContext {
-                    timeframe: "1h".into(),
+                    timeframe: tf("1h"),
                     reason: SecondaryContextUnavailableReason::Stale,
                 }],
             },
@@ -1199,10 +1248,10 @@ fn coarse_required_secondary_remains_fresh_until_duration_and_tolerance_are_exce
         ]
     );
     assert_eq!(
-        runtime.market_history("1m"),
+        runtime.market_history(tf("1m")),
         Some(&[fresh_primary, stale_primary][..])
     );
-    assert_eq!(runtime.market_history("1h"), Some(&[secondary][..]));
+    assert_eq!(runtime.market_history(tf("1h")), Some(&[secondary][..]));
 }
 
 #[test]
@@ -1211,7 +1260,10 @@ fn optional_secondary_stale_emits_diagnostic_but_allows_same_strategy_tick() {
     let primary = candle(3_600_001, "1m", 101.0);
     let calls = Rc::new(RefCell::new(0));
     let mut runtime = TradingRuntime::with_config(
-        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::optional("1h", 0)]),
+        runtime_config_with_secondary_configs(
+            "1m",
+            [SecondaryTimeframeConfig::optional(tf("1h"), 0)],
+        ),
         PortfolioState::new(1_000.0),
         0,
         CountingStrategyHandler::from_decisions(
@@ -1232,7 +1284,7 @@ fn optional_secondary_stale_emits_diagnostic_but_allows_same_strategy_tick() {
         .events
         .contains(&RuntimeEvent::SecondaryContextUnavailable {
             candle: primary.clone(),
-            timeframe: "1h".into(),
+            timeframe: tf("1h"),
             readiness: SecondaryReadiness::Optional,
             reason: SecondaryContextUnavailableReason::Stale,
         }));
@@ -1257,7 +1309,10 @@ fn required_and_optional_secondary_differ_for_the_same_stale_context() {
     let required_calls = Rc::new(RefCell::new(0));
     let optional_calls = Rc::new(RefCell::new(0));
     let mut required_runtime = TradingRuntime::with_config(
-        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::required("1h", 0)]),
+        runtime_config_with_secondary_configs(
+            "1m",
+            [SecondaryTimeframeConfig::required(tf("1h"), 0)],
+        ),
         PortfolioState::new(1_000.0),
         0,
         CountingStrategyHandler::from_decisions(
@@ -1266,7 +1321,10 @@ fn required_and_optional_secondary_differ_for_the_same_stale_context() {
         ),
     );
     let mut optional_runtime = TradingRuntime::with_config(
-        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::optional("1h", 0)]),
+        runtime_config_with_secondary_configs(
+            "1m",
+            [SecondaryTimeframeConfig::optional(tf("1h"), 0)],
+        ),
         PortfolioState::new(1_000.0),
         0,
         CountingStrategyHandler::from_decisions(
@@ -1300,7 +1358,7 @@ fn required_and_optional_secondary_differ_for_the_same_stale_context() {
         .events
         .contains(&RuntimeEvent::SecondaryContextUnavailable {
             candle: primary,
-            timeframe: "1h".into(),
+            timeframe: tf("1h"),
             readiness: SecondaryReadiness::Optional,
             reason: SecondaryContextUnavailableReason::Stale,
         }));
@@ -1313,7 +1371,10 @@ fn fine_secondary_freshness_uses_secondary_duration_not_primary_duration() {
     let primary = candle(180_001, "1h", 101.0);
     let calls = Rc::new(RefCell::new(0));
     let mut runtime = TradingRuntime::with_config(
-        runtime_config_with_secondary_configs("1h", [SecondaryTimeframeConfig::required("1m", 1)]),
+        runtime_config_with_secondary_configs(
+            "1h",
+            [SecondaryTimeframeConfig::required(tf("1m"), 1)],
+        ),
         PortfolioState::new(1_000.0),
         0,
         CountingStrategyHandler::from_decisions(
@@ -1342,13 +1403,13 @@ fn fine_secondary_freshness_uses_secondary_duration_not_primary_duration() {
             RuntimeEvent::StrategyTickBlocked {
                 candle: primary.clone(),
                 blocked_contexts: vec![BlockedSecondaryContext {
-                    timeframe: "1m".into(),
+                    timeframe: tf("1m"),
                     reason: SecondaryContextUnavailableReason::Stale,
                 }],
             },
             RuntimeEvent::TradableCandleCompleted,
         ]
     );
-    assert_eq!(runtime.market_history("1h"), Some(&[primary][..]));
-    assert_eq!(runtime.market_history("1m"), Some(&[secondary][..]));
+    assert_eq!(runtime.market_history(tf("1h")), Some(&[primary][..]));
+    assert_eq!(runtime.market_history(tf("1m")), Some(&[secondary][..]));
 }

--- a/trading-runtime/tests/market_input.rs
+++ b/trading-runtime/tests/market_input.rs
@@ -1,0 +1,292 @@
+use shared::Candle;
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
+use trading_runtime::{
+    ExecutionAction, MarketInput, PortfolioState, RuntimeConfig, RuntimeEvent, RuntimeInputError,
+    RuntimePortfolioSnapshot, StrategyDecision, StrategyHandler, TradingRuntime,
+};
+
+fn candle(timestamp: i64, timeframe: &str, close: f64) -> Candle {
+    Candle {
+        timestamp,
+        symbol: "BTC-USD".into(),
+        open: close,
+        high: close,
+        low: close,
+        close,
+        volume: 1_000.0,
+        timeframe: timeframe.into(),
+    }
+}
+
+fn runtime_config() -> RuntimeConfig {
+    RuntimeConfig::new("BTC-USD", "1m", ["1h"])
+}
+
+#[derive(Clone)]
+struct CountingStrategyHandler {
+    calls: Rc<RefCell<usize>>,
+    decisions: VecDeque<StrategyDecision>,
+}
+
+impl CountingStrategyHandler {
+    fn from_decisions(
+        calls: Rc<RefCell<usize>>,
+        decisions: impl IntoIterator<Item = StrategyDecision>,
+    ) -> Self {
+        Self {
+            calls,
+            decisions: decisions.into_iter().collect(),
+        }
+    }
+}
+
+impl StrategyHandler for CountingStrategyHandler {
+    fn next_decision(
+        &mut self,
+        _candle: &Candle,
+        _portfolio: &RuntimePortfolioSnapshot,
+    ) -> StrategyDecision {
+        *self.calls.borrow_mut() += 1;
+        self.decisions
+            .pop_front()
+            .unwrap_or_else(StrategyDecision::hold)
+    }
+}
+
+#[test]
+fn completed_primary_market_input_routes_to_existing_tradable_candle_behavior() {
+    let primary = candle(1, "1m", 100.0);
+    let decision = StrategyDecision::open_long(2.0);
+    let calls = Rc::new(RefCell::new(0));
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config(),
+        PortfolioState::new(1_000.0),
+        0,
+        CountingStrategyHandler::from_decisions(Rc::clone(&calls), [decision.clone()]),
+    );
+
+    let step = runtime
+        .on_market_input(MarketInput::CompletedCandle(primary.clone()))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 1);
+    assert_eq!(
+        step.events,
+        vec![
+            RuntimeEvent::MarketInputAccepted {
+                candle: primary.clone(),
+            },
+            RuntimeEvent::TradableTickStarted {
+                candle: primary.clone(),
+            },
+            RuntimeEvent::StrategyDecisionProduced { decision },
+            RuntimeEvent::ExecutionActionPlanned {
+                action: ExecutionAction::OpenLong {
+                    quantity: 2.0,
+                    stop_loss: None,
+                    take_profit: None,
+                },
+            },
+            RuntimeEvent::PositionOpened {
+                position: step.portfolio_snapshot.open_position.clone().unwrap(),
+            },
+            RuntimeEvent::PortfolioUpdated {
+                snapshot: step.portfolio_snapshot.clone(),
+            },
+            RuntimeEvent::TradableTickCompleted,
+        ]
+    );
+    assert!(step.portfolio_snapshot.open_position.is_some());
+}
+
+#[test]
+fn warmup_primary_market_input_routes_to_existing_warmup_behavior() {
+    let primary_warmup = candle(1, "1m", 100.0);
+    let calls = Rc::new(RefCell::new(0));
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config(),
+        PortfolioState::new(1_000.0),
+        2,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&calls),
+            [StrategyDecision::open_long(2.0)],
+        ),
+    );
+
+    let step = runtime
+        .on_market_input(MarketInput::WarmupCandle(primary_warmup.clone()))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 0);
+    assert_eq!(
+        step.events,
+        vec![
+            RuntimeEvent::WarmupInputAccepted {
+                candle: primary_warmup.clone(),
+            },
+            RuntimeEvent::WarmupAdvanced {
+                current_warmup_input_count: 1,
+                required_warmup_inputs: 2,
+            },
+        ]
+    );
+    assert_eq!(
+        step.portfolio_snapshot,
+        PortfolioState::new(1_000.0).snapshot(primary_warmup.close)
+    );
+}
+
+#[test]
+fn warmup_secondary_market_input_is_accepted_without_strategy_or_portfolio_transition() {
+    let secondary_warmup = candle(1, "1h", 100.0);
+    let calls = Rc::new(RefCell::new(0));
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config(),
+        PortfolioState::new(1_000.0),
+        2,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&calls),
+            [StrategyDecision::open_long(2.0)],
+        ),
+    );
+
+    let step = runtime
+        .on_market_input(MarketInput::WarmupCandle(secondary_warmup.clone()))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 0);
+    assert_eq!(
+        step.events,
+        vec![
+            RuntimeEvent::WarmupInputAccepted {
+                candle: secondary_warmup.clone(),
+            },
+            RuntimeEvent::WarmupAdvanced {
+                current_warmup_input_count: 1,
+                required_warmup_inputs: 2,
+            },
+        ]
+    );
+    assert_eq!(
+        step.portfolio_snapshot,
+        PortfolioState::new(1_000.0).snapshot(secondary_warmup.close)
+    );
+}
+
+#[test]
+fn completed_secondary_market_input_is_accepted_without_strategy_or_portfolio_transition() {
+    let secondary = candle(1, "1h", 100.0);
+    let primary = candle(2, "1m", 101.0);
+    let decision = StrategyDecision::open_long(2.0);
+    let calls = Rc::new(RefCell::new(0));
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config(),
+        PortfolioState::new(1_000.0),
+        0,
+        CountingStrategyHandler::from_decisions(Rc::clone(&calls), [decision.clone()]),
+    );
+
+    let secondary_step = runtime
+        .on_market_input(MarketInput::CompletedCandle(secondary.clone()))
+        .unwrap();
+
+    assert_eq!(
+        secondary_step.events,
+        vec![RuntimeEvent::MarketInputAccepted {
+            candle: secondary.clone(),
+        }]
+    );
+    assert_eq!(*calls.borrow(), 0);
+    assert_eq!(
+        secondary_step.portfolio_snapshot,
+        PortfolioState::new(1_000.0).snapshot(secondary.close)
+    );
+
+    let primary_step = runtime
+        .on_market_input(MarketInput::CompletedCandle(primary))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 1);
+    assert_eq!(
+        primary_step
+            .portfolio_snapshot
+            .open_position
+            .as_ref()
+            .map(|position| position.size),
+        Some(2.0)
+    );
+}
+
+#[test]
+fn unknown_timeframe_returns_input_error_without_consuming_strategy_decisions() {
+    let unknown = candle(1, "5m", 100.0);
+    let primary = candle(2, "1m", 101.0);
+    let decision = StrategyDecision::open_long(2.0);
+    let calls = Rc::new(RefCell::new(0));
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config(),
+        PortfolioState::new(1_000.0),
+        0,
+        CountingStrategyHandler::from_decisions(Rc::clone(&calls), [decision]),
+    );
+
+    let error = runtime
+        .on_market_input(MarketInput::CompletedCandle(unknown))
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        RuntimeInputError::UnknownTimeframe {
+            timeframe: "5m".into(),
+        }
+    );
+    assert_eq!(*calls.borrow(), 0);
+
+    let primary_step = runtime
+        .on_market_input(MarketInput::CompletedCandle(primary))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 1);
+    assert!(primary_step.portfolio_snapshot.open_position.is_some());
+}
+
+#[test]
+fn unknown_timeframe_returns_input_error_without_advancing_warmup() {
+    let unknown = candle(1, "5m", 100.0);
+    let primary_warmup = candle(2, "1m", 101.0);
+    let calls = Rc::new(RefCell::new(0));
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config(),
+        PortfolioState::new(1_000.0),
+        2,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&calls),
+            [StrategyDecision::open_long(2.0)],
+        ),
+    );
+
+    let error = runtime
+        .on_market_input(MarketInput::WarmupCandle(unknown))
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        RuntimeInputError::UnknownTimeframe {
+            timeframe: "5m".into(),
+        }
+    );
+
+    let warmup_step = runtime
+        .on_market_input(MarketInput::WarmupCandle(primary_warmup))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 0);
+    assert!(warmup_step.events.contains(&RuntimeEvent::WarmupAdvanced {
+        current_warmup_input_count: 1,
+        required_warmup_inputs: 2,
+    }));
+    assert!(!warmup_step
+        .events
+        .iter()
+        .any(|event| matches!(event, RuntimeEvent::WarmupCompleted { .. })));
+}

--- a/trading-runtime/tests/market_input.rs
+++ b/trading-runtime/tests/market_input.rs
@@ -2,7 +2,9 @@ use shared::{Candle, Position, PositionSide};
 use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 use trading_runtime::{
     ExecutionAction, MarketInput, PortfolioState, RuntimeConfig, RuntimeEvent, RuntimeInputError,
-    RuntimePortfolioSnapshot, StrategyDecision, StrategyHandler, TradingRuntime,
+    RuntimePortfolioSnapshot, SecondaryContextUnavailableReason, SecondaryReadiness,
+    SecondaryTimeframeConfig, StrategyDecision, StrategyHandler, StrategyTickBlockedReason,
+    TradingRuntime,
 };
 
 fn candle(timestamp: i64, timeframe: &str, close: f64) -> Candle {
@@ -108,6 +110,12 @@ fn completed_primary_market_input_emits_tradable_candle_and_strategy_tick_events
             },
             RuntimeEvent::TradableCandleAccepted {
                 candle: primary.clone(),
+            },
+            RuntimeEvent::SecondaryContextUnavailable {
+                candle: primary.clone(),
+                timeframe: "1h".into(),
+                readiness: SecondaryReadiness::Optional,
+                reason: SecondaryContextUnavailableReason::Missing,
             },
             RuntimeEvent::StrategyTickStarted {
                 candle: primary.clone(),
@@ -724,4 +732,261 @@ fn unknown_timeframe_error_leaves_existing_market_state_histories_unchanged() {
     assert_eq!(runtime.market_history("1m"), Some(&primary_before[..]));
     assert_eq!(runtime.market_history("1h"), Some(&secondary_before[..]));
     assert_eq!(runtime.market_history("5m"), None);
+}
+
+fn runtime_config_with_secondary_configs(
+    primary_timeframe: &str,
+    secondary_timeframes: impl IntoIterator<Item = SecondaryTimeframeConfig>,
+) -> RuntimeConfig {
+    RuntimeConfig::with_secondary_configs("BTC-USD", primary_timeframe, secondary_timeframes)
+}
+
+#[test]
+fn required_secondary_missing_blocks_strategy_tick_after_storing_primary() {
+    let primary = candle(60_000, "1m", 100.0);
+    let calls = Rc::new(RefCell::new(0));
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::required("1h", 0)]),
+        PortfolioState::new(1_000.0),
+        0,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&calls),
+            [StrategyDecision::open_long(2.0)],
+        ),
+    );
+
+    let step = runtime
+        .on_market_input(MarketInput::CompletedCandle(primary.clone()))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 0);
+    assert_eq!(runtime.market_history("1m"), Some(&[primary.clone()][..]));
+    assert_eq!(runtime.market_history("1h"), Some(&[][..]));
+    assert_eq!(
+        step.events,
+        vec![
+            RuntimeEvent::MarketInputAccepted {
+                candle: primary.clone(),
+            },
+            RuntimeEvent::TradableCandleAccepted {
+                candle: primary.clone(),
+            },
+            RuntimeEvent::StrategyTickBlocked {
+                candle: primary.clone(),
+                reason: StrategyTickBlockedReason::RequiredSecondaryUnavailable {
+                    timeframe: "1h".into(),
+                },
+            },
+            RuntimeEvent::TradableCandleCompleted,
+        ]
+    );
+    assert!(!step.events.iter().any(|event| matches!(
+        event,
+        RuntimeEvent::StrategyTickStarted { .. }
+            | RuntimeEvent::StrategyDecisionProduced { .. }
+            | RuntimeEvent::ExecutionActionPlanned { .. }
+    )));
+}
+
+#[test]
+fn coarse_required_secondary_remains_fresh_until_duration_and_tolerance_are_exceeded() {
+    let secondary = candle(0, "1h", 100.0);
+    let fresh_primary = candle(3_600_000, "1m", 101.0);
+    let stale_primary = candle(7_200_001, "1m", 102.0);
+    let calls = Rc::new(RefCell::new(0));
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::required("1h", 1)]),
+        PortfolioState::new(1_000.0),
+        0,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&calls),
+            [StrategyDecision::hold(), StrategyDecision::open_long(2.0)],
+        ),
+    );
+
+    runtime
+        .on_market_input(MarketInput::CompletedCandle(secondary.clone()))
+        .unwrap();
+    let fresh_step = runtime
+        .on_market_input(MarketInput::CompletedCandle(fresh_primary.clone()))
+        .unwrap();
+    let stale_step = runtime
+        .on_market_input(MarketInput::CompletedCandle(stale_primary.clone()))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 1);
+    assert!(fresh_step
+        .events
+        .iter()
+        .any(|event| matches!(event, RuntimeEvent::StrategyDecisionProduced { .. })));
+    assert_eq!(
+        stale_step.events,
+        vec![
+            RuntimeEvent::MarketInputAccepted {
+                candle: stale_primary.clone(),
+            },
+            RuntimeEvent::TradableCandleAccepted {
+                candle: stale_primary.clone(),
+            },
+            RuntimeEvent::StrategyTickBlocked {
+                candle: stale_primary.clone(),
+                reason: StrategyTickBlockedReason::RequiredSecondaryStale {
+                    timeframe: "1h".into(),
+                },
+            },
+            RuntimeEvent::TradableCandleCompleted,
+        ]
+    );
+    assert_eq!(
+        runtime.market_history("1m"),
+        Some(&[fresh_primary, stale_primary][..])
+    );
+    assert_eq!(runtime.market_history("1h"), Some(&[secondary][..]));
+}
+
+#[test]
+fn optional_secondary_stale_emits_diagnostic_but_allows_same_strategy_tick() {
+    let secondary = candle(0, "1h", 100.0);
+    let primary = candle(3_600_001, "1m", 101.0);
+    let calls = Rc::new(RefCell::new(0));
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::optional("1h", 0)]),
+        PortfolioState::new(1_000.0),
+        0,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&calls),
+            [StrategyDecision::open_long(2.0)],
+        ),
+    );
+
+    runtime
+        .on_market_input(MarketInput::CompletedCandle(secondary.clone()))
+        .unwrap();
+    let step = runtime
+        .on_market_input(MarketInput::CompletedCandle(primary.clone()))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 1);
+    assert!(step
+        .events
+        .contains(&RuntimeEvent::SecondaryContextUnavailable {
+            candle: primary.clone(),
+            timeframe: "1h".into(),
+            readiness: SecondaryReadiness::Optional,
+            reason: SecondaryContextUnavailableReason::Stale,
+        }));
+    assert!(step
+        .events
+        .iter()
+        .any(|event| matches!(event, RuntimeEvent::StrategyDecisionProduced { .. })));
+    assert!(step
+        .events
+        .iter()
+        .any(|event| matches!(event, RuntimeEvent::PositionOpened { .. })));
+    assert!(!step
+        .events
+        .iter()
+        .any(|event| matches!(event, RuntimeEvent::StrategyTickBlocked { .. })));
+}
+
+#[test]
+fn required_and_optional_secondary_differ_for_the_same_stale_context() {
+    let secondary = candle(0, "1h", 100.0);
+    let primary = candle(3_600_001, "1m", 101.0);
+    let required_calls = Rc::new(RefCell::new(0));
+    let optional_calls = Rc::new(RefCell::new(0));
+    let mut required_runtime = TradingRuntime::with_config(
+        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::required("1h", 0)]),
+        PortfolioState::new(1_000.0),
+        0,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&required_calls),
+            [StrategyDecision::open_long(2.0)],
+        ),
+    );
+    let mut optional_runtime = TradingRuntime::with_config(
+        runtime_config_with_secondary_configs("1m", [SecondaryTimeframeConfig::optional("1h", 0)]),
+        PortfolioState::new(1_000.0),
+        0,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&optional_calls),
+            [StrategyDecision::open_long(2.0)],
+        ),
+    );
+
+    required_runtime
+        .on_market_input(MarketInput::CompletedCandle(secondary.clone()))
+        .unwrap();
+    optional_runtime
+        .on_market_input(MarketInput::CompletedCandle(secondary))
+        .unwrap();
+    let required_step = required_runtime
+        .on_market_input(MarketInput::CompletedCandle(primary.clone()))
+        .unwrap();
+    let optional_step = optional_runtime
+        .on_market_input(MarketInput::CompletedCandle(primary.clone()))
+        .unwrap();
+
+    assert_eq!(*required_calls.borrow(), 0);
+    assert!(required_step
+        .events
+        .iter()
+        .any(|event| matches!(event, RuntimeEvent::StrategyTickBlocked { .. })));
+    assert!(required_step.portfolio_snapshot.open_position.is_none());
+
+    assert_eq!(*optional_calls.borrow(), 1);
+    assert!(optional_step
+        .events
+        .contains(&RuntimeEvent::SecondaryContextUnavailable {
+            candle: primary,
+            timeframe: "1h".into(),
+            readiness: SecondaryReadiness::Optional,
+            reason: SecondaryContextUnavailableReason::Stale,
+        }));
+    assert!(optional_step.portfolio_snapshot.open_position.is_some());
+}
+
+#[test]
+fn fine_secondary_freshness_uses_secondary_duration_not_primary_duration() {
+    let secondary = candle(60_000, "1m", 100.0);
+    let primary = candle(180_001, "1h", 101.0);
+    let calls = Rc::new(RefCell::new(0));
+    let mut runtime = TradingRuntime::with_config(
+        runtime_config_with_secondary_configs("1h", [SecondaryTimeframeConfig::required("1m", 1)]),
+        PortfolioState::new(1_000.0),
+        0,
+        CountingStrategyHandler::from_decisions(
+            Rc::clone(&calls),
+            [StrategyDecision::open_long(2.0)],
+        ),
+    );
+
+    runtime
+        .on_market_input(MarketInput::CompletedCandle(secondary.clone()))
+        .unwrap();
+    let step = runtime
+        .on_market_input(MarketInput::CompletedCandle(primary.clone()))
+        .unwrap();
+
+    assert_eq!(*calls.borrow(), 0);
+    assert_eq!(
+        step.events,
+        vec![
+            RuntimeEvent::MarketInputAccepted {
+                candle: primary.clone(),
+            },
+            RuntimeEvent::TradableCandleAccepted {
+                candle: primary.clone(),
+            },
+            RuntimeEvent::StrategyTickBlocked {
+                candle: primary.clone(),
+                reason: StrategyTickBlockedReason::RequiredSecondaryStale {
+                    timeframe: "1m".into(),
+                },
+            },
+            RuntimeEvent::TradableCandleCompleted,
+        ]
+    );
+    assert_eq!(runtime.market_history("1h"), Some(&[primary][..]));
+    assert_eq!(runtime.market_history("1m"), Some(&[secondary][..]));
 }

--- a/trading-runtime/tests/risk_exit.rs
+++ b/trading-runtime/tests/risk_exit.rs
@@ -1,4 +1,4 @@
-use shared::{Candle, Position, PositionSide};
+use shared::{Candle, Position, PositionSide, Timeframe};
 use trading_runtime::{evaluate_risk_exit, RiskExitKind, RiskExitTriggered};
 
 fn position(side: PositionSide, stop_loss: Option<f64>, take_profit: Option<f64>) -> Position {
@@ -22,7 +22,7 @@ fn candle(open: f64, high: f64, low: f64, close: f64) -> Candle {
         low,
         close,
         volume: 1_000.0,
-        timeframe: "1m".into(),
+        timeframe: Timeframe::minutes(1),
     }
 }
 

--- a/trading-runtime/tests/risk_exit_regressions.rs
+++ b/trading-runtime/tests/risk_exit_regressions.rs
@@ -1,9 +1,9 @@
 use shared::{Candle, Position, PositionSide};
 use std::{cell::RefCell, rc::Rc};
 use trading_runtime::{
-    ClosedPosition, ExecutionAction, ExitKind, PortfolioState, RiskExitKind, RiskExitTriggered,
-    RuntimeEvent, RuntimePortfolioSnapshot, RuntimeStep, StrategyDecision, StrategyHandler,
-    TradingRuntime,
+    ClosedPosition, ExecutionAction, ExitKind, MarketInput, PortfolioState, RiskExitKind,
+    RiskExitTriggered, RuntimeEvent, RuntimePortfolioSnapshot, RuntimeStep, StrategyDecision,
+    StrategyHandler, TradingRuntime,
 };
 
 fn ohlc_candle(timestamp: i64, open: f64, high: f64, low: f64, close: f64) -> Candle {
@@ -17,6 +17,15 @@ fn ohlc_candle(timestamp: i64, open: f64, high: f64, low: f64, close: f64) -> Ca
         volume: 1_000.0,
         timeframe: "1m".into(),
     }
+}
+
+fn completed_primary_step<S: StrategyHandler>(
+    runtime: &mut TradingRuntime<S>,
+    candle: Candle,
+) -> RuntimeStep {
+    runtime
+        .on_market_input(MarketInput::CompletedCandle(candle))
+        .expect("completed primary candle should be accepted")
 }
 
 fn position_with_entry_risk(
@@ -119,7 +128,7 @@ fn regression_long_stop_loss_uses_stop_price_not_legacy_candle_close() {
     let exit_candle = ohlc_candle(2, 100.0, 105.0, 90.0, 88.0);
     let (mut runtime, strategy_calls) = runtime_with_open_position(open_position.clone(), 0);
 
-    let step = runtime.on_tradable_candle(exit_candle.clone());
+    let step = completed_primary_step(&mut runtime, exit_candle.clone());
 
     assert_eq!(
         risk_exit_event(&step),
@@ -162,7 +171,7 @@ fn regression_short_stop_loss_uses_stop_price_not_legacy_candle_close() {
     let exit_candle = ohlc_candle(2, 100.0, 110.0, 95.0, 115.0);
     let (mut runtime, strategy_calls) = runtime_with_open_position(open_position.clone(), 0);
 
-    let step = runtime.on_tradable_candle(exit_candle.clone());
+    let step = completed_primary_step(&mut runtime, exit_candle.clone());
 
     assert_eq!(
         risk_exit_event(&step),
@@ -197,7 +206,7 @@ fn regression_take_profit_uses_target_price_not_legacy_candle_close() {
     let exit_candle = ohlc_candle(2, 100.0, 120.0, 95.0, 112.0);
     let (mut runtime, strategy_calls) = runtime_with_open_position(open_position, 0);
 
-    let step = runtime.on_tradable_candle(exit_candle.clone());
+    let step = completed_primary_step(&mut runtime, exit_candle.clone());
 
     assert_eq!(
         risk_exit_event(&step),
@@ -230,7 +239,7 @@ fn regression_both_intrabar_boundaries_select_stop_loss_and_expose_both_triggere
     let exit_candle = ohlc_candle(2, 100.0, 120.0, 90.0, 110.0);
     let (mut runtime, strategy_calls) = runtime_with_open_position(open_position, 0);
 
-    let step = runtime.on_tradable_candle(exit_candle);
+    let step = completed_primary_step(&mut runtime, exit_candle);
 
     assert_eq!(
         risk_exit_event(&step),
@@ -289,7 +298,7 @@ fn regression_first_tradable_candle_after_warmup_can_close_breached_stop_before_
     let (mut runtime, strategy_calls) = runtime_with_open_position(open_position, 1);
 
     let warmup_step = runtime.on_warmup_input(warmup_candle);
-    let tradable_step = runtime.on_tradable_candle(first_tradable_candle.clone());
+    let tradable_step = completed_primary_step(&mut runtime, first_tradable_candle.clone());
 
     assert!(warmup_step.portfolio_snapshot.open_position.is_some());
     assert_eq!(

--- a/trading-runtime/tests/risk_exit_regressions.rs
+++ b/trading-runtime/tests/risk_exit_regressions.rs
@@ -1,4 +1,4 @@
-use shared::{Candle, Position, PositionSide};
+use shared::{Candle, Position, PositionSide, Timeframe};
 use std::{cell::RefCell, rc::Rc};
 use trading_runtime::{
     ClosedPosition, ExecutionAction, ExitKind, MarketInput, PortfolioState, RiskExitKind,
@@ -15,7 +15,7 @@ fn ohlc_candle(timestamp: i64, open: f64, high: f64, low: f64, close: f64) -> Ca
         low,
         close,
         volume: 1_000.0,
-        timeframe: "1m".into(),
+        timeframe: Timeframe::minutes(1),
     }
 }
 

--- a/trading-runtime/tests/risk_exit_regressions.rs
+++ b/trading-runtime/tests/risk_exit_regressions.rs
@@ -106,8 +106,10 @@ fn execution_action_event(step: &RuntimeStep) -> &ExecutionAction {
 fn assert_no_strategy_tick_events(step: &RuntimeStep) {
     assert!(step.events.iter().all(|event| !matches!(
         event,
-        RuntimeEvent::StrategyDecisionProduced { .. }
+        RuntimeEvent::StrategyTickStarted { .. }
+            | RuntimeEvent::StrategyDecisionProduced { .. }
             | RuntimeEvent::StrategyDecisionIgnored { .. }
+            | RuntimeEvent::StrategyTickCompleted
     )));
 }
 
@@ -269,7 +271,9 @@ fn regression_warmup_input_crossing_stop_loss_does_not_close_or_emit_risk_exit()
             | RuntimeEvent::ExecutionActionPlanned { .. }
             | RuntimeEvent::PositionClosed { .. }
             | RuntimeEvent::PortfolioUpdated { .. }
-            | RuntimeEvent::TradableTickStarted { .. }
+            | RuntimeEvent::TradableCandleAccepted { .. }
+            | RuntimeEvent::StrategyTickStarted { .. }
+            | RuntimeEvent::StrategyTickCompleted
     )));
     assert_eq!(step.portfolio_snapshot.open_position, Some(open_position));
     assert_eq!(step.portfolio_snapshot.completed_trade_count, 0);

--- a/trading-runtime/tests/runtime_step.rs
+++ b/trading-runtime/tests/runtime_step.rs
@@ -1,3 +1,4 @@
+use shared::Timeframe;
 use trading_runtime::{
     BlockedSecondaryContext, ExitKind, RiskExitKind, RuntimeEvent, RuntimeStep,
     SecondaryContextUnavailableReason, StrategyDecision,
@@ -12,7 +13,7 @@ fn candle() -> shared::Candle {
         low: 99.0,
         close: 100.0,
         volume: 1_000.0,
-        timeframe: "1m".into(),
+        timeframe: Timeframe::minutes(1),
     }
 }
 
@@ -79,7 +80,7 @@ fn blocked_strategy_tick_can_complete_tradable_candle_without_strategy_output() 
             RuntimeEvent::StrategyTickBlocked {
                 candle: candle.clone(),
                 blocked_contexts: vec![BlockedSecondaryContext {
-                    timeframe: "1h".into(),
+                    timeframe: Timeframe::hours(1),
                     reason: SecondaryContextUnavailableReason::Missing,
                 }],
             },
@@ -94,7 +95,7 @@ fn blocked_strategy_tick_can_complete_tradable_candle_without_strategy_output() 
             blocked_contexts,
             ..
         } if blocked_contexts == &vec![BlockedSecondaryContext {
-            timeframe: "1h".into(),
+            timeframe: Timeframe::hours(1),
             reason: SecondaryContextUnavailableReason::Missing,
         }]
     )));

--- a/trading-runtime/tests/runtime_step.rs
+++ b/trading-runtime/tests/runtime_step.rs
@@ -1,5 +1,6 @@
 use trading_runtime::{
-    ExitKind, RiskExitKind, RuntimeEvent, RuntimeStep, StrategyDecision, StrategyTickBlockedReason,
+    BlockedSecondaryContext, ExitKind, RiskExitKind, RuntimeEvent, RuntimeStep,
+    SecondaryContextUnavailableReason, StrategyDecision,
 };
 
 fn candle() -> shared::Candle {
@@ -77,9 +78,10 @@ fn blocked_strategy_tick_can_complete_tradable_candle_without_strategy_output() 
             },
             RuntimeEvent::StrategyTickBlocked {
                 candle: candle.clone(),
-                reason: StrategyTickBlockedReason::RequiredSecondaryUnavailable {
+                blocked_contexts: vec![BlockedSecondaryContext {
                     timeframe: "1h".into(),
-                },
+                    reason: SecondaryContextUnavailableReason::Missing,
+                }],
             },
             RuntimeEvent::TradableCandleCompleted,
         ],
@@ -89,9 +91,12 @@ fn blocked_strategy_tick_can_complete_tradable_candle_without_strategy_output() 
     assert!(step.events.iter().any(|event| matches!(
         event,
         RuntimeEvent::StrategyTickBlocked {
-            reason: StrategyTickBlockedReason::RequiredSecondaryUnavailable { timeframe },
+            blocked_contexts,
             ..
-        } if timeframe == "1h"
+        } if blocked_contexts == &vec![BlockedSecondaryContext {
+            timeframe: "1h".into(),
+            reason: SecondaryContextUnavailableReason::Missing,
+        }]
     )));
     assert!(!step.events.iter().any(|event| matches!(
         event,

--- a/trading-runtime/tests/runtime_step.rs
+++ b/trading-runtime/tests/runtime_step.rs
@@ -1,4 +1,6 @@
-use trading_runtime::{ExitKind, RiskExitKind, RuntimeEvent, RuntimeStep, StrategyDecision};
+use trading_runtime::{
+    ExitKind, RiskExitKind, RuntimeEvent, RuntimeStep, StrategyDecision, StrategyTickBlockedReason,
+};
 
 fn candle() -> shared::Candle {
     shared::Candle {
@@ -18,7 +20,7 @@ fn snapshot() -> trading_runtime::RuntimePortfolioSnapshot {
 }
 
 #[test]
-fn runtime_step_returns_ordered_events_and_current_portfolio_snapshot() {
+fn runtime_step_returns_ordered_strategy_tick_events_and_current_portfolio_snapshot() {
     let candle = candle();
     let snapshot = snapshot();
     let step = RuntimeStep::new(
@@ -26,12 +28,17 @@ fn runtime_step_returns_ordered_events_and_current_portfolio_snapshot() {
             RuntimeEvent::MarketInputAccepted {
                 candle: candle.clone(),
             },
-            RuntimeEvent::TradableTickStarted {
+            RuntimeEvent::TradableCandleAccepted {
+                candle: candle.clone(),
+            },
+            RuntimeEvent::StrategyTickStarted {
                 candle: candle.clone(),
             },
             RuntimeEvent::StrategyDecisionProduced {
                 decision: StrategyDecision::hold(),
             },
+            RuntimeEvent::StrategyTickCompleted,
+            RuntimeEvent::TradableCandleCompleted,
         ],
         snapshot.clone(),
     );
@@ -42,13 +49,54 @@ fn runtime_step_returns_ordered_events_and_current_portfolio_snapshot() {
             RuntimeEvent::MarketInputAccepted {
                 candle: candle.clone(),
             },
-            RuntimeEvent::TradableTickStarted { candle },
+            RuntimeEvent::TradableCandleAccepted {
+                candle: candle.clone(),
+            },
+            RuntimeEvent::StrategyTickStarted { candle },
             RuntimeEvent::StrategyDecisionProduced {
                 decision: StrategyDecision::hold(),
             },
+            RuntimeEvent::StrategyTickCompleted,
+            RuntimeEvent::TradableCandleCompleted,
         ]
     );
     assert_eq!(step.portfolio_snapshot, snapshot);
+}
+
+#[test]
+fn blocked_strategy_tick_can_complete_tradable_candle_without_strategy_output() {
+    let candle = candle();
+    let snapshot = snapshot();
+    let step = RuntimeStep::new(
+        vec![
+            RuntimeEvent::MarketInputAccepted {
+                candle: candle.clone(),
+            },
+            RuntimeEvent::TradableCandleAccepted {
+                candle: candle.clone(),
+            },
+            RuntimeEvent::StrategyTickBlocked {
+                candle: candle.clone(),
+                reason: StrategyTickBlockedReason::RequiredSecondaryUnavailable {
+                    timeframe: "1h".into(),
+                },
+            },
+            RuntimeEvent::TradableCandleCompleted,
+        ],
+        snapshot,
+    );
+
+    assert!(step.events.iter().any(|event| matches!(
+        event,
+        RuntimeEvent::StrategyTickBlocked {
+            reason: StrategyTickBlockedReason::RequiredSecondaryUnavailable { timeframe },
+            ..
+        } if timeframe == "1h"
+    )));
+    assert!(!step.events.iter().any(|event| matches!(
+        event,
+        RuntimeEvent::StrategyDecisionProduced { .. } | RuntimeEvent::ExecutionActionPlanned { .. }
+    )));
 }
 
 #[test]

--- a/trading-runtime/tests/trading_runtime.rs
+++ b/trading-runtime/tests/trading_runtime.rs
@@ -60,7 +60,10 @@ fn assert_ignored_step(
             RuntimeEvent::MarketInputAccepted {
                 candle: candle.clone(),
             },
-            RuntimeEvent::TradableTickStarted { candle },
+            RuntimeEvent::TradableCandleAccepted {
+                candle: candle.clone(),
+            },
+            RuntimeEvent::StrategyTickStarted { candle },
             RuntimeEvent::StrategyDecisionProduced {
                 decision: decision.clone(),
             },
@@ -68,7 +71,8 @@ fn assert_ignored_step(
                 action: ExecutionAction::Noop,
             },
             RuntimeEvent::StrategyDecisionIgnored { decision, reason },
-            RuntimeEvent::TradableTickCompleted,
+            RuntimeEvent::StrategyTickCompleted,
+            RuntimeEvent::TradableCandleCompleted,
         ]
     );
     assert_eq!(step.portfolio_snapshot, expected_snapshot);
@@ -147,7 +151,7 @@ fn assert_risk_exit_step(
             RuntimeEvent::MarketInputAccepted {
                 candle: exit_candle.clone(),
             },
-            RuntimeEvent::TradableTickStarted {
+            RuntimeEvent::TradableCandleAccepted {
                 candle: exit_candle,
             },
             RuntimeEvent::RiskExitTriggered {
@@ -169,7 +173,7 @@ fn assert_risk_exit_step(
             RuntimeEvent::PortfolioUpdated {
                 snapshot: expected_snapshot.clone(),
             },
-            RuntimeEvent::TradableTickCompleted,
+            RuntimeEvent::TradableCandleCompleted,
         ]
     );
     assert_eq!(*strategy_calls.borrow(), 0);
@@ -262,7 +266,7 @@ fn tradable_candle_with_both_intrabar_boundaries_selects_stop_loss_and_reports_b
 }
 
 #[test]
-fn tradable_candle_with_no_warmup_and_hold_while_flat_emits_tradable_noop_step() {
+fn tradable_candle_with_no_warmup_and_hold_while_flat_emits_strategy_tick_noop_step() {
     let candle = candle(1, 100.0);
     let mut runtime = TradingRuntime::new(
         PortfolioState::new(1_000.0),
@@ -278,7 +282,10 @@ fn tradable_candle_with_no_warmup_and_hold_while_flat_emits_tradable_noop_step()
             RuntimeEvent::MarketInputAccepted {
                 candle: candle.clone(),
             },
-            RuntimeEvent::TradableTickStarted {
+            RuntimeEvent::TradableCandleAccepted {
+                candle: candle.clone(),
+            },
+            RuntimeEvent::StrategyTickStarted {
                 candle: candle.clone(),
             },
             RuntimeEvent::StrategyDecisionProduced {
@@ -287,7 +294,8 @@ fn tradable_candle_with_no_warmup_and_hold_while_flat_emits_tradable_noop_step()
             RuntimeEvent::ExecutionActionPlanned {
                 action: ExecutionAction::Noop,
             },
-            RuntimeEvent::TradableTickCompleted,
+            RuntimeEvent::StrategyTickCompleted,
+            RuntimeEvent::TradableCandleCompleted,
         ]
     );
     assert_eq!(
@@ -368,7 +376,10 @@ fn warmup_input_advances_market_progress_without_calling_strategy_until_complete
             RuntimeEvent::MarketInputAccepted {
                 candle: first_tradable.clone(),
             },
-            RuntimeEvent::TradableTickStarted {
+            RuntimeEvent::TradableCandleAccepted {
+                candle: first_tradable.clone(),
+            },
+            RuntimeEvent::StrategyTickStarted {
                 candle: first_tradable.clone(),
             },
             RuntimeEvent::StrategyDecisionProduced { decision },
@@ -390,7 +401,8 @@ fn warmup_input_advances_market_progress_without_calling_strategy_until_complete
             RuntimeEvent::PortfolioUpdated {
                 snapshot: tradable_step.portfolio_snapshot.clone(),
             },
-            RuntimeEvent::TradableTickCompleted,
+            RuntimeEvent::StrategyTickCompleted,
+            RuntimeEvent::TradableCandleCompleted,
         ]
     );
     assert_eq!(
@@ -444,7 +456,7 @@ fn warmup_input_crossing_stop_loss_on_initial_open_position_does_not_trade() {
             | RuntimeEvent::RiskExitTriggered { .. }
             | RuntimeEvent::PositionClosed { .. }
             | RuntimeEvent::PortfolioUpdated { .. }
-            | RuntimeEvent::TradableTickStarted { .. }
+            | RuntimeEvent::TradableCandleAccepted { .. }
     )));
 }
 
@@ -466,7 +478,7 @@ fn zero_warmup_makes_first_tradable_candle_tradable_without_warmup_completed() {
     assert!(step
         .events
         .iter()
-        .any(|event| matches!(event, RuntimeEvent::TradableTickStarted { .. })));
+        .any(|event| matches!(event, RuntimeEvent::TradableCandleAccepted { .. })));
 }
 
 #[test]
@@ -493,7 +505,10 @@ fn tradable_candle_opens_long_from_flat_and_updates_portfolio_snapshot() {
             RuntimeEvent::MarketInputAccepted {
                 candle: candle.clone(),
             },
-            RuntimeEvent::TradableTickStarted {
+            RuntimeEvent::TradableCandleAccepted {
+                candle: candle.clone(),
+            },
+            RuntimeEvent::StrategyTickStarted {
                 candle: candle.clone(),
             },
             RuntimeEvent::StrategyDecisionProduced { decision },
@@ -510,7 +525,8 @@ fn tradable_candle_opens_long_from_flat_and_updates_portfolio_snapshot() {
             RuntimeEvent::PortfolioUpdated {
                 snapshot: expected_snapshot.clone(),
             },
-            RuntimeEvent::TradableTickCompleted,
+            RuntimeEvent::StrategyTickCompleted,
+            RuntimeEvent::TradableCandleCompleted,
         ]
     );
     assert_eq!(step.portfolio_snapshot, expected_snapshot);
@@ -549,7 +565,10 @@ fn tradable_candle_opens_short_from_flat_and_updates_portfolio_snapshot() {
             RuntimeEvent::MarketInputAccepted {
                 candle: candle.clone(),
             },
-            RuntimeEvent::TradableTickStarted {
+            RuntimeEvent::TradableCandleAccepted {
+                candle: candle.clone(),
+            },
+            RuntimeEvent::StrategyTickStarted {
                 candle: candle.clone(),
             },
             RuntimeEvent::StrategyDecisionProduced { decision },
@@ -566,7 +585,8 @@ fn tradable_candle_opens_short_from_flat_and_updates_portfolio_snapshot() {
             RuntimeEvent::PortfolioUpdated {
                 snapshot: expected_snapshot.clone(),
             },
-            RuntimeEvent::TradableTickCompleted,
+            RuntimeEvent::StrategyTickCompleted,
+            RuntimeEvent::TradableCandleCompleted,
         ]
     );
     assert_eq!(step.portfolio_snapshot, expected_snapshot);
@@ -828,7 +848,10 @@ fn tradable_candle_closes_long_position_and_realizes_pnl() {
             RuntimeEvent::MarketInputAccepted {
                 candle: exit_candle.clone(),
             },
-            RuntimeEvent::TradableTickStarted {
+            RuntimeEvent::TradableCandleAccepted {
+                candle: exit_candle.clone(),
+            },
+            RuntimeEvent::StrategyTickStarted {
                 candle: exit_candle.clone(),
             },
             RuntimeEvent::StrategyDecisionProduced {
@@ -844,7 +867,8 @@ fn tradable_candle_closes_long_position_and_realizes_pnl() {
             RuntimeEvent::PortfolioUpdated {
                 snapshot: expected_snapshot.clone(),
             },
-            RuntimeEvent::TradableTickCompleted,
+            RuntimeEvent::StrategyTickCompleted,
+            RuntimeEvent::TradableCandleCompleted,
         ]
     );
     assert_eq!(step.portfolio_snapshot, expected_snapshot);
@@ -1061,7 +1085,10 @@ fn tradable_candle_closes_short_position_and_realizes_pnl() {
             RuntimeEvent::MarketInputAccepted {
                 candle: exit_candle.clone(),
             },
-            RuntimeEvent::TradableTickStarted {
+            RuntimeEvent::TradableCandleAccepted {
+                candle: exit_candle.clone(),
+            },
+            RuntimeEvent::StrategyTickStarted {
                 candle: exit_candle.clone(),
             },
             RuntimeEvent::StrategyDecisionProduced {
@@ -1077,7 +1104,8 @@ fn tradable_candle_closes_short_position_and_realizes_pnl() {
             RuntimeEvent::PortfolioUpdated {
                 snapshot: expected_snapshot.clone(),
             },
-            RuntimeEvent::TradableTickCompleted,
+            RuntimeEvent::StrategyTickCompleted,
+            RuntimeEvent::TradableCandleCompleted,
         ]
     );
     assert_eq!(step.portfolio_snapshot, expected_snapshot);

--- a/trading-runtime/tests/trading_runtime.rs
+++ b/trading-runtime/tests/trading_runtime.rs
@@ -1,4 +1,4 @@
-use shared::{Candle, Position, PositionSide};
+use shared::{Candle, Position, PositionSide, Timeframe};
 use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 use trading_runtime::{
     ClosedPosition, ExecutionAction, ExitKind, ForceCloseIgnoredReason, IgnoredDecisionReason,
@@ -20,7 +20,7 @@ fn ohlc_candle(timestamp: i64, open: f64, high: f64, low: f64, close: f64) -> Ca
         low,
         close,
         volume: 1_000.0,
-        timeframe: "1m".into(),
+        timeframe: Timeframe::minutes(1),
     }
 }
 
@@ -347,7 +347,7 @@ fn warmup_input_advances_market_progress_without_calling_strategy_until_complete
                 candle: first_warmup.clone(),
             },
             RuntimeEvent::WarmupAdvanced {
-                timeframe: "1m".into(),
+                timeframe: Timeframe::minutes(1),
                 current_warmup_input_count: 1,
                 required_warmup_inputs: 2,
             },
@@ -364,12 +364,12 @@ fn warmup_input_advances_market_progress_without_calling_strategy_until_complete
                 candle: second_warmup.clone(),
             },
             RuntimeEvent::WarmupAdvanced {
-                timeframe: "1m".into(),
+                timeframe: Timeframe::minutes(1),
                 current_warmup_input_count: 2,
                 required_warmup_inputs: 2,
             },
             RuntimeEvent::WarmupCompleted {
-                completed_timeframes: vec!["1m".into()],
+                completed_timeframes: vec![Timeframe::minutes(1)],
                 required_warmup_inputs: 2,
             },
         ]
@@ -446,12 +446,12 @@ fn warmup_input_crossing_stop_loss_on_initial_open_position_does_not_trade() {
                 candle: warmup.clone(),
             },
             RuntimeEvent::WarmupAdvanced {
-                timeframe: "1m".into(),
+                timeframe: Timeframe::minutes(1),
                 current_warmup_input_count: 1,
                 required_warmup_inputs: 1,
             },
             RuntimeEvent::WarmupCompleted {
-                completed_timeframes: vec!["1m".into()],
+                completed_timeframes: vec![Timeframe::minutes(1)],
                 required_warmup_inputs: 1,
             },
         ]
@@ -1314,7 +1314,7 @@ fn force_close_works_while_runtime_is_still_in_warmup() {
                 candle: warmup_candle.clone(),
             },
             RuntimeEvent::WarmupAdvanced {
-                timeframe: "1m".into(),
+                timeframe: Timeframe::minutes(1),
                 current_warmup_input_count: 1,
                 required_warmup_inputs: 3,
             },

--- a/trading-runtime/tests/trading_runtime.rs
+++ b/trading-runtime/tests/trading_runtime.rs
@@ -330,6 +330,7 @@ fn warmup_input_advances_market_progress_without_calling_strategy_until_complete
                 candle: first_warmup.clone(),
             },
             RuntimeEvent::WarmupAdvanced {
+                timeframe: "1m".into(),
                 current_warmup_input_count: 1,
                 required_warmup_inputs: 2,
             },
@@ -346,11 +347,13 @@ fn warmup_input_advances_market_progress_without_calling_strategy_until_complete
                 candle: second_warmup.clone(),
             },
             RuntimeEvent::WarmupAdvanced {
+                timeframe: "1m".into(),
                 current_warmup_input_count: 2,
                 required_warmup_inputs: 2,
             },
             RuntimeEvent::WarmupCompleted {
-                completed_warmup_input_count: 2,
+                completed_timeframes: vec!["1m".into()],
+                required_warmup_inputs: 2,
             },
         ]
     );
@@ -422,11 +425,13 @@ fn warmup_input_crossing_stop_loss_on_initial_open_position_does_not_trade() {
                 candle: warmup.clone(),
             },
             RuntimeEvent::WarmupAdvanced {
+                timeframe: "1m".into(),
                 current_warmup_input_count: 1,
                 required_warmup_inputs: 1,
             },
             RuntimeEvent::WarmupCompleted {
-                completed_warmup_input_count: 1,
+                completed_timeframes: vec!["1m".into()],
+                required_warmup_inputs: 1,
             },
         ]
     );
@@ -1272,6 +1277,7 @@ fn force_close_works_while_runtime_is_still_in_warmup() {
                 candle: warmup_candle.clone(),
             },
             RuntimeEvent::WarmupAdvanced {
+                timeframe: "1m".into(),
                 current_warmup_input_count: 1,
                 required_warmup_inputs: 3,
             },

--- a/trading-runtime/tests/trading_runtime.rs
+++ b/trading-runtime/tests/trading_runtime.rs
@@ -2,9 +2,9 @@ use shared::{Candle, Position, PositionSide};
 use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 use trading_runtime::{
     ClosedPosition, ExecutionAction, ExitKind, ForceCloseIgnoredReason, IgnoredDecisionReason,
-    PortfolioState, PredeterminedStrategyHandler, RiskExitKind, RiskExitTriggered, RuntimeEvent,
-    RuntimePortfolioSnapshot, StrategyDecision, StrategyDecisionIntent, StrategyHandler,
-    TradingRuntime,
+    MarketInput, PortfolioState, PredeterminedStrategyHandler, RiskExitKind, RiskExitTriggered,
+    RuntimeEvent, RuntimePortfolioSnapshot, StrategyDecision, StrategyDecisionIntent,
+    StrategyHandler, TradingRuntime,
 };
 
 fn candle(timestamp: i64, close: f64) -> Candle {
@@ -26,6 +26,15 @@ fn ohlc_candle(timestamp: i64, open: f64, high: f64, low: f64, close: f64) -> Ca
 
 fn position(side: PositionSide, entry_time: i64, entry_price: f64, size: f64) -> Position {
     position_with_entry_risk(side, entry_time, entry_price, size, None, None)
+}
+
+fn completed_primary_step<S: StrategyHandler>(
+    runtime: &mut TradingRuntime<S>,
+    candle: Candle,
+) -> trading_runtime::RuntimeStep {
+    runtime
+        .on_market_input(MarketInput::CompletedCandle(candle))
+        .expect("completed primary candle should be accepted")
 }
 
 fn position_with_entry_risk(
@@ -143,7 +152,7 @@ fn assert_risk_exit_step(
         ),
     );
 
-    let step = runtime.on_tradable_candle(exit_candle.clone());
+    let step = completed_primary_step(&mut runtime, exit_candle.clone());
 
     assert_eq!(
         step.events,
@@ -274,7 +283,7 @@ fn tradable_candle_with_no_warmup_and_hold_while_flat_emits_strategy_tick_noop_s
         PredeterminedStrategyHandler::from_decisions([StrategyDecision::hold()]),
     );
 
-    let step = runtime.on_tradable_candle(candle.clone());
+    let step = completed_primary_step(&mut runtime, candle.clone());
 
     assert_eq!(
         step.events,
@@ -329,7 +338,7 @@ fn warmup_input_advances_market_progress_without_calling_strategy_until_complete
 
     let first_step = runtime.on_warmup_input(first_warmup.clone());
     let second_step = runtime.on_warmup_input(second_warmup.clone());
-    let tradable_step = runtime.on_tradable_candle(first_tradable.clone());
+    let tradable_step = completed_primary_step(&mut runtime, first_tradable.clone());
 
     assert_eq!(
         first_step.events,
@@ -469,7 +478,7 @@ fn zero_warmup_makes_first_tradable_candle_tradable_without_warmup_completed() {
         PredeterminedStrategyHandler::from_decisions([StrategyDecision::hold()]),
     );
 
-    let step = runtime.on_tradable_candle(candle);
+    let step = completed_primary_step(&mut runtime, candle);
 
     assert!(!step
         .events
@@ -497,7 +506,7 @@ fn tradable_candle_opens_long_from_flat_and_updates_portfolio_snapshot() {
         .unwrap();
     let expected_snapshot = expected_portfolio.snapshot(candle.close);
 
-    let step = runtime.on_tradable_candle(candle.clone());
+    let step = completed_primary_step(&mut runtime, candle.clone());
 
     assert_eq!(
         step.events,
@@ -557,7 +566,7 @@ fn tradable_candle_opens_short_from_flat_and_updates_portfolio_snapshot() {
         .unwrap();
     let expected_snapshot = expected_portfolio.snapshot(candle.close);
 
-    let step = runtime.on_tradable_candle(candle.clone());
+    let step = completed_primary_step(&mut runtime, candle.clone());
 
     assert_eq!(
         step.events,
@@ -619,7 +628,7 @@ fn tradable_candle_opens_long_with_valid_entry_risk_boundaries() {
         Some(120.0),
     );
 
-    let step = runtime.on_tradable_candle(candle.clone());
+    let step = completed_primary_step(&mut runtime, candle.clone());
 
     assert!(step.events.contains(&RuntimeEvent::ExecutionActionPlanned {
         action: ExecutionAction::OpenLong {
@@ -655,7 +664,7 @@ fn tradable_candle_opens_short_with_valid_entry_risk_boundaries() {
         Some(80.0),
     );
 
-    let step = runtime.on_tradable_candle(candle.clone());
+    let step = completed_primary_step(&mut runtime, candle.clone());
 
     assert!(step.events.contains(&RuntimeEvent::ExecutionActionPlanned {
         action: ExecutionAction::OpenShort {
@@ -696,7 +705,7 @@ fn tradable_candle_opens_with_one_valid_entry_risk_boundary() {
             PredeterminedStrategyHandler::from_decisions([decision]),
         );
 
-        let step = runtime.on_tradable_candle(candle.clone());
+        let step = completed_primary_step(&mut runtime, candle.clone());
 
         assert_eq!(
             step.portfolio_snapshot.open_position,
@@ -745,7 +754,7 @@ fn tradable_candle_ignores_invalid_entry_risk_without_portfolio_transition() {
             PredeterminedStrategyHandler::from_decisions([decision.clone()]),
         );
 
-        let step = runtime.on_tradable_candle(candle.clone());
+        let step = completed_primary_step(&mut runtime, candle.clone());
 
         assert_ignored_step(
             step,
@@ -767,7 +776,7 @@ fn invalid_quantity_wins_before_invalid_entry_risk_while_flat() {
         PredeterminedStrategyHandler::from_decisions([decision.clone()]),
     );
 
-    let step = runtime.on_tradable_candle(candle.clone());
+    let step = completed_primary_step(&mut runtime, candle.clone());
 
     assert_ignored_step(
         step,
@@ -791,13 +800,13 @@ fn position_already_open_wins_before_invalid_quantity_or_entry_risk() {
             decision.clone(),
         ]),
     );
-    runtime.on_tradable_candle(entry_candle.clone());
+    completed_primary_step(&mut runtime, entry_candle.clone());
     let mut expected_portfolio = PortfolioState::new(1_000.0);
     expected_portfolio
         .open_long_from_flat(&entry_candle, 2.0, None, None)
         .unwrap();
 
-    let step = runtime.on_tradable_candle(invalid_candle.clone());
+    let step = completed_primary_step(&mut runtime, invalid_candle.clone());
 
     assert_ignored_step(
         step,
@@ -820,7 +829,7 @@ fn tradable_candle_closes_long_position_and_realizes_pnl() {
             StrategyDecision::close_long(),
         ]),
     );
-    runtime.on_tradable_candle(entry_candle.clone());
+    completed_primary_step(&mut runtime, entry_candle.clone());
     let opened_position = position(
         PositionSide::Long,
         entry_candle.timestamp,
@@ -840,7 +849,7 @@ fn tradable_candle_closes_long_position_and_realizes_pnl() {
     expected_portfolio.close_long(&exit_candle).unwrap();
     let expected_snapshot = expected_portfolio.snapshot(exit_candle.close);
 
-    let step = runtime.on_tradable_candle(exit_candle.clone());
+    let step = completed_primary_step(&mut runtime, exit_candle.clone());
 
     assert_eq!(
         step.events,
@@ -892,7 +901,7 @@ fn tradable_candle_ignores_invalid_opening_quantities_without_portfolio_transiti
             PredeterminedStrategyHandler::from_decisions([decision.clone()]),
         );
 
-        let step = runtime.on_tradable_candle(candle.clone());
+        let step = completed_primary_step(&mut runtime, candle.clone());
 
         assert_ignored_step(
             step,
@@ -914,7 +923,7 @@ fn tradable_candle_ignores_close_decision_while_flat_without_portfolio_transitio
         PredeterminedStrategyHandler::from_decisions([decision.clone()]),
     );
 
-    let step = runtime.on_tradable_candle(candle.clone());
+    let step = completed_primary_step(&mut runtime, candle.clone());
 
     assert_ignored_step(
         step,
@@ -938,13 +947,13 @@ fn tradable_candle_ignores_close_long_while_short_without_portfolio_transition()
             decision.clone(),
         ]),
     );
-    runtime.on_tradable_candle(entry_candle.clone());
+    completed_primary_step(&mut runtime, entry_candle.clone());
     let mut expected_portfolio = PortfolioState::new(1_000.0);
     expected_portfolio
         .open_short_from_flat(&entry_candle, 2.0, None, None)
         .unwrap();
 
-    let step = runtime.on_tradable_candle(invalid_candle.clone());
+    let step = completed_primary_step(&mut runtime, invalid_candle.clone());
 
     assert_ignored_step(
         step,
@@ -968,13 +977,13 @@ fn tradable_candle_ignores_close_short_while_long_without_portfolio_transition()
             decision.clone(),
         ]),
     );
-    runtime.on_tradable_candle(entry_candle.clone());
+    completed_primary_step(&mut runtime, entry_candle.clone());
     let mut expected_portfolio = PortfolioState::new(1_000.0);
     expected_portfolio
         .open_long_from_flat(&entry_candle, 2.0, None, None)
         .unwrap();
 
-    let step = runtime.on_tradable_candle(invalid_candle.clone());
+    let step = completed_primary_step(&mut runtime, invalid_candle.clone());
 
     assert_ignored_step(
         step,
@@ -998,13 +1007,13 @@ fn tradable_candle_ignores_open_long_while_already_long_without_portfolio_transi
             decision.clone(),
         ]),
     );
-    runtime.on_tradable_candle(entry_candle.clone());
+    completed_primary_step(&mut runtime, entry_candle.clone());
     let mut expected_portfolio = PortfolioState::new(1_000.0);
     expected_portfolio
         .open_long_from_flat(&entry_candle, 2.0, None, None)
         .unwrap();
 
-    let step = runtime.on_tradable_candle(invalid_candle.clone());
+    let step = completed_primary_step(&mut runtime, invalid_candle.clone());
 
     assert_ignored_step(
         step,
@@ -1028,13 +1037,13 @@ fn tradable_candle_ignores_open_short_while_already_short_without_portfolio_tran
             decision.clone(),
         ]),
     );
-    runtime.on_tradable_candle(entry_candle.clone());
+    completed_primary_step(&mut runtime, entry_candle.clone());
     let mut expected_portfolio = PortfolioState::new(1_000.0);
     expected_portfolio
         .open_short_from_flat(&entry_candle, 2.0, None, None)
         .unwrap();
 
-    let step = runtime.on_tradable_candle(invalid_candle.clone());
+    let step = completed_primary_step(&mut runtime, invalid_candle.clone());
 
     assert_ignored_step(
         step,
@@ -1057,7 +1066,7 @@ fn tradable_candle_closes_short_position_and_realizes_pnl() {
             StrategyDecision::close_short(),
         ]),
     );
-    runtime.on_tradable_candle(entry_candle.clone());
+    completed_primary_step(&mut runtime, entry_candle.clone());
     let opened_position = position(
         PositionSide::Short,
         entry_candle.timestamp,
@@ -1077,7 +1086,7 @@ fn tradable_candle_closes_short_position_and_realizes_pnl() {
     expected_portfolio.close_short(&exit_candle).unwrap();
     let expected_snapshot = expected_portfolio.snapshot(exit_candle.close);
 
-    let step = runtime.on_tradable_candle(exit_candle.clone());
+    let step = completed_primary_step(&mut runtime, exit_candle.clone());
 
     assert_eq!(
         step.events,
@@ -1124,7 +1133,7 @@ fn force_close_closes_open_long_position_with_ordered_events() {
         0,
         PredeterminedStrategyHandler::from_decisions([StrategyDecision::open_long(2.0)]),
     );
-    runtime.on_tradable_candle(entry_candle.clone());
+    completed_primary_step(&mut runtime, entry_candle.clone());
     let opened_position = position(
         PositionSide::Long,
         entry_candle.timestamp,
@@ -1182,7 +1191,7 @@ fn force_close_closes_open_short_position_with_ordered_events() {
         0,
         PredeterminedStrategyHandler::from_decisions([StrategyDecision::open_short(2.0)]),
     );
-    runtime.on_tradable_candle(entry_candle.clone());
+    completed_primary_step(&mut runtime, entry_candle.clone());
     let opened_position = position(
         PositionSide::Short,
         entry_candle.timestamp,


### PR DESCRIPTION
## Summary
- Add typed `Timeframe` value object and market input boundary for runtime data.
- Track multi-timeframe market state and warmup readiness.
- Split tradable candle handling from secondary timeframe context events.

## Notes
- Breaking change: timeframe usage now goes through the typed value object instead of legacy string handling.

## Tests
- Not run (PR creation only).