### PR TITLE
issue series/typed rhai strategy handling

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,8 +5,8 @@ This file documents the domain language used by TradingBot2 contributors and str
 ## Language
 
 **Strategy State**:
-Memory that belongs to one running strategy and persists between ticks. Strategy State is visible to Rhai strategies through the strategy context and is not the authoritative account or portfolio state.
-_Avoid_: State, Engine State
+Session-local memory that belongs to one running strategy and persists between Strategy Ticks. Strategy State is visible through the Strategy Context and is distinct from Market State, Compute State, and Portfolio State.
+_Avoid_: State, Engine State, Portfolio State, Market State
 
 **Portfolio State**:
 The canonical trading state of a live or simulated trading session: realized cash balance, open position, and completed trade count. Equity is derived from Portfolio State and current market prices rather than treated as independent account truth; a run may start from an initial completed trade count and then continue counting completed trades from there.
@@ -31,6 +31,14 @@ _Avoid_: Strategy Engine when portfolio/execution coordination is meant
 **Strategy Hook**:
 A named strategy function that the runtime may call at a defined point in the trading session. Missing optional hooks use runtime defaults or no-op behavior.
 _Avoid_: Callback, magic function
+
+**Strategy Configuration**:
+Strategy-declared requirements or defaults that the Trading Runtime can inspect before Strategy Ticks, such as minimum warmup and Secondary-Timeframe requirements. Strategy Configuration does not choose the Runtime Asset, Primary Timeframe, live/backtest mode, or Portfolio State.
+_Avoid_: Run Configuration, Strategy State
+
+**Run Configuration**:
+Operator- or runner-owned configuration for a Trading Runtime, including the Runtime Asset, Primary Timeframe, mode/source choices, and authoritative overrides for configured Secondary Timeframes.
+_Avoid_: Strategy Configuration, Strategy State
 
 **Strategy Decision**:
 The strategy-produced intent for the current Strategy Tick, using explicit direction-aware intents such as HOLD, OPEN_LONG, CLOSE_LONG, OPEN_SHORT, and CLOSE_SHORT. Opening decisions use quantity to mean asset units/contracts, not a balance fraction; a Strategy Decision is interpreted by the Trading Runtime before any portfolio transition occurs.
@@ -65,7 +73,7 @@ A change to Portfolio State, such as opening a position, closing a position, or 
 _Avoid_: DB update, backtest metric
 
 **Warmup Requirement**:
-The amount of market history a Trading Runtime needs before Strategy Ticks are allowed. For multi-timeframe runs, the first model applies the same Warmup Requirement as a per-timeframe history requirement to the Primary Timeframe and configured Secondary Timeframes. The Trading Runtime determines the Warmup Requirement; runners are responsible for fetching and supplying the required market data.
+The amount of market history a Trading Runtime needs before Strategy Ticks are allowed. In multi-timeframe runs, Warmup Requirements are understood per configured timeframe; the first model may resolve the same requirement for every configured timeframe. The Trading Runtime determines the Warmup Requirement; runners are responsible for fetching and supplying the required market data.
 _Avoid_: Runner warmup policy, arbitrary startup delay
 
 **Warmup Phase**:
@@ -121,7 +129,7 @@ The runtime-held market history available to strategy evaluation, potentially ac
 _Avoid_: Candle argument when multiple timeframes are meant
 
 **Market View**:
-The strategy-facing view of Market State. A Market View exposes the current Primary Timeframe candle by default and can expose the latest known completed Secondary-Timeframe candles when requested. Market View candle histories keep the existing strategy-facing convention that index 1 is the newest visible candle and higher indexes move backward in that timeframe. If an optional Secondary Timeframe is unavailable, the corresponding Market View access returns no value; if a required Secondary Timeframe is unavailable, the Strategy Tick is blocked before strategy evaluation.
+The strategy-facing view of Market State and market-derived structure outputs. A Market View exposes the current Primary Timeframe candle by default, can expose latest known completed Secondary-Timeframe candles when requested, and may expose anchored/structure-aware outputs derived from market history. Market View candle histories keep the existing strategy-facing convention that index 1 is the newest visible candle and higher indexes move backward in that timeframe. If an optional Secondary Timeframe is unavailable, the corresponding Market View access returns no value; if a required Secondary Timeframe is unavailable, the Strategy Tick is blocked before strategy evaluation.
 _Avoid_: Context when market data is meant
 
 **Strategy Context**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3264,6 +3264,7 @@ dependencies = [
 name = "trading-runtime"
 version = "0.1.0"
 dependencies = [
+ "rhai",
  "shared",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3264,6 +3264,7 @@ dependencies = [
 name = "trading-runtime"
 version = "0.1.0"
 dependencies = [
+ "indicators",
  "rhai",
  "shared",
 ]

--- a/docs/adr/0005-use-typed-rhai-strategy-api.md
+++ b/docs/adr/0005-use-typed-rhai-strategy-api.md
@@ -1,0 +1,42 @@
+# Use typed Rhai strategy APIs instead of stringly typed maps
+
+- Status: accepted
+- Date: 2026-05-29
+
+The new Trading Runtime exposes strategy-facing Rhai APIs as typed custom values built through constructors and fluent methods rather than as loosely parsed object maps and magic strings. This applies to Strategy Decisions, Strategy Configuration, Timeframes, Secondary-Timeframe requirements, and Anchored/structure-aware configuration.
+
+Examples of the intended shape:
+
+```rhai
+const H1 = timeframe("1h");
+
+fn strategy_config() {
+    strategy_config::new()
+        .with_minimum_warmup(200)
+        .with_secondary(
+            secondary::required(H1)
+                .with_max_missing_candles(1)
+        )
+}
+
+fn on_tick(market, context) {
+    let h1 = market.candle(H1);
+
+    decision::open_long(2.0)
+        .with_stop_loss(95.0)
+        .with_take_profit(120.0)
+        .with_reason("breakout")
+}
+```
+
+The old engine's legacy return shape, such as `#{ signal: "BUY", size: 0.5 }`, is not supported in the new Strategy Handling path. New stringly typed maps, such as `#{ intent: "OPEN_LONG" }`, are also not the primary API. Raw strings are acceptable at explicit parsing boundaries such as `timeframe("1h")`, where they are immediately validated and converted into typed values.
+
+## Considered options
+
+- Keep the old `signal`/`size` map shape — rejected because it preserves legacy ambiguity and conflicts with ADR 0004.
+- Use new maps with fields like `intent`, `quantity`, `timeframe`, or `readiness` — rejected because they still rely on magic strings and shape parsing where typed constructors are clearer.
+- Use typed Rhai custom values via constructors and fluent methods — accepted because it gives strategy authors readable APIs while letting the runtime receive typed decisions/configuration.
+
+## Consequences
+
+Strategy examples and docs should use typed constructors and fluent methods such as `decision::*`, `strategy_config::new()`, `secondary::required(...)`, `.with_stop_loss(...)`, `.with_take_profit(...)`, and `.with_reason(...)`. Legacy `signal`/`size` returns are unsupported and should produce clear strategy errors rather than compatibility mapping. Fluent risk methods are part of the StrategyDecision custom type API; using them where they do not apply, such as on `hold` or close decisions, should produce a clear strategy error rather than silently mutating an irrelevant decision. `.with_reason(...)` is allowed for all decisions and remains diagnostic only.

--- a/engine/src/vm.rs
+++ b/engine/src/vm.rs
@@ -963,14 +963,10 @@ fn on_tick(candles, context) {
     }
 
     #[test]
-    fn trendline_break_strategy_loads() {
-        // Loads the actual strategy file from disk — exercises the full spec parse.
-        let src = std::fs::read_to_string(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../strategies/trendline_break.rhai"
-        ))
-        .expect("read trendline_break.rhai");
-        let mut e = Engine::new(&src).expect("engine should load");
+    fn legacy_anchored_fixture_loads() {
+        // The maintained strategies/ examples now target the typed Trading Runtime API.
+        // Keep this old-engine donor coverage on an inline legacy fixture instead.
+        let mut e = Engine::new(ANCHORED).expect("engine should load legacy fixture");
         // A single HOLD tick must not crash (no anchored output yet).
         let d = e.tick(make_candle(100.0, 1), flat_ctx()).unwrap();
         assert_eq!(d.signal, Signal::Hold);

--- a/engine/src/warmup_detector.rs
+++ b/engine/src/warmup_detector.rs
@@ -275,10 +275,19 @@ mod tests {
     }
 
     #[test]
-    fn sma_cross_strategy_detects_slow_period() {
-        let src = std::fs::read_to_string("../strategies/sma_cross.rhai").unwrap();
-        let (ast, scope) = compile(&src);
-        // Strategy currently uses FAST=50, SLOW=200 → max+1 = 201
+    fn legacy_sma_cross_fixture_detects_slow_period() {
+        let src = r#"
+            const FAST = 50;
+            const SLOW = 200;
+
+            fn on_tick(candles, context) {
+                let fast = indicators::sma(candles, FAST);
+                let slow = indicators::sma(candles, SLOW);
+                #{ signal: "HOLD" }
+            }
+        "#;
+        let (ast, scope) = compile(src);
+        // Legacy engine donor fixture uses FAST=50, SLOW=200 → max+1 = 201.
         assert_eq!(detect_warmup_period(&ast, &scope), 201);
     }
 }

--- a/strategies/README.md
+++ b/strategies/README.md
@@ -1,236 +1,244 @@
-# Writing strategies
+# Writing typed Runtime strategies
 
-This folder contains `.rhai` trading strategies.
+This folder contains `.rhai` examples for the Trading Runtime typed Strategy
+Handling API. The current target API is the runtime-owned Rhai path described in
+[ADR 0005](../docs/adr/0005-use-typed-rhai-strategy-api.md), not the legacy
+`engine` API.
 
 Use this README as the practical guide for creating a new strategy. Use
 [`REFERENCE.md`](./REFERENCE.md) for the exact public Rhai API.
 
 ## Quick start
 
-1. Copy a starter strategy into this folder.
+1. Copy one of the maintained examples in this folder.
 2. Rename it to match your intent.
-3. Edit the constants and `on_tick` logic.
-4. Backtest it.
-5. Only then wire it into the live daemon config.
+3. Keep the required hook as `fn on_tick(market, context)`.
+4. Return typed decisions from `decision::*`.
+5. Declare optional warmup/Secondary requirements in `strategy_config()`.
+6. Declare optional anchored/structure compute in `anchored_config()`.
 
-### Backtest loop
+The live daemon and backtester migration to the new runtime API is tracked
+separately. These examples are validated against `trading-runtime`'s typed Rhai
+loader and runtime tick path.
 
-```bash
-just backtest --strategy strategies/my_strategy.rhai --symbol AAPL --interval 1d
-```
+## Required hook
 
-If you do not have candles yet:
-
-```bash
-just seed
-```
-
-To run the live daemon with a strategy path from `trading-bot.toml`:
-
-```bash
-just run
-```
-
-## Folder conventions
-
-- Put new strategy files in `strategies/`.
-- Use a `.rhai` filename.
-- Add an optional header comment near the top:
+Every strategy must define:
 
 ```rhai
-// name: "my_strategy"
-```
-
-- Keep the header name, filename, and strategy intent aligned.
-- Prefer top-level `const` values for tunable parameters.
-- Start from one of the two reference examples in this folder:
-  - `sma_cross.rhai` for rolling indicators
-  - `trendline_break.rhai` for anchored indicators
-
-## Execution model
-
-- Top-level code runs once when the strategy is loaded.
-- `fn on_tick(candles, context)` runs once per visible candle.
-- `fn anchored_config()` is optional and is called once at load time.
-- Backtest warmup is auto-detected from `indicators::*` calls when possible.
-- Even with auto warmup, indicators can still return `()` during startup, so keep explicit warmup guards in strategy code.
-
-## Starter template: rolling indicators
-
-```rhai
-// name: "my_strategy"
-
-const FAST = 20;
-const SLOW = 50;
-
-fn on_tick(candles, context) {
-    let fast      = indicators::ema(candles, FAST);
-    let slow      = indicators::sma(candles, SLOW);
-    let fast_prev = indicators::ema(candles, FAST, 1);
-    let slow_prev = indicators::sma(candles, SLOW, 1);
-
-    if fast == () || slow == () || fast_prev == () || slow_prev == () {
-        return #{ signal: "HOLD", reason: "warming up" };
-    }
-
-    let crossed_up   = fast_prev <= slow_prev && fast > slow;
-    let crossed_down = fast_prev >= slow_prev && fast < slow;
-
-    if crossed_up && !context.has_position() {
-        return #{
-            signal: "BUY",
-            size: 0.5,
-            reason: "fast crossed above slow",
-        };
-    }
-
-    if crossed_down && context.has_position() {
-        return #{
-            signal: "SELL",
-            reason: "fast crossed below slow",
-        };
-    }
-
-    #{ signal: "HOLD" }
+fn on_tick(market, context) {
+    decision::hold()
 }
 ```
 
-## Starter template: anchored indicators
+`market` is the Market View: it contains Primary and configured Secondary market
+data plus market-derived anchored outputs. `context` is the Strategy Context: it
+contains grouped runtime session information such as `context.portfolio` and
+`context.state`.
+
+## Decisions
+
+Return a typed `StrategyDecision` from the `decision` module:
 
 ```rhai
-// name: "my_anchored_strategy"
+decision::hold()
+decision::open_long(1.0)
+decision::close_long()
+decision::open_short(1.0)
+decision::close_short()
+```
 
-const PIVOT_LEFT   = 5;
-const PIVOT_RIGHT  = 5;
-const PIVOT_BUFFER = 6;
-const TOLERANCE    = 0.002;
-const MIN_TOUCHES  = 3;
+Opening decisions take quantity in asset units/contracts. They can attach
+runtime-managed entry risk parameters with fluent methods:
 
+```rhai
+fn on_tick(market, context) {
+    let c = market.candle();
+
+    decision::open_long(1.0)
+        .with_stop_loss(c.close * 0.95)
+        .with_take_profit(c.close * 1.10)
+        .with_reason("breakout with hard exits")
+}
+```
+
+`.with_reason(...)` is allowed on any decision and is diagnostic only.
+`.with_stop_loss(...)` and `.with_take_profit(...)` are only valid on opening
+decisions.
+
+## Market View
+
+Primary-Timeframe access:
+
+```rhai
+let c = market.candle();
+let candles = market.candles();
+let newest = candles[1];
+```
+
+Candle histories are 1-indexed and newest-first for strategy authors:
+`market.candles()[1]` is the current Primary candle. Out-of-range indexes return
+`()`. Indicator bindings consume histories returned by `market.candles(...)`:
+
+```rhai
+fn on_tick(market, context) {
+    let fast = indicators::sma(market.candles(), 20);
+    let slow = indicators::sma(market.candles(), 50);
+
+    if fast == () || slow == () {
+        return decision::hold().with_reason("warming up");
+    }
+
+    if fast > slow {
+        decision::open_long(1.0)
+            .with_stop_loss(market.candle().close * 0.95)
+            .with_reason("sma crossover")
+    } else {
+        decision::hold()
+    }
+}
+```
+
+## Strategy configuration and Secondary Timeframes
+
+`strategy_config()` is optional. Use it for strategy-declared minimum warmup and
+Secondary-Timeframe requirements/defaults only. The run configuration remains
+authoritative for the Runtime Asset and Primary Timeframe.
+
+```rhai
+const H1 = timeframe("1h");
+
+fn strategy_config() {
+    strategy_config::new()
+        .with_minimum_warmup(200)
+        .with_secondary(
+            secondary::required(H1)
+                .with_max_missing_candles(1)
+        )
+}
+
+fn on_tick(market, context) {
+    let primary = market.candle();
+    let h1 = market.candle(H1);
+
+    decision::hold().with_reason("read primary + H1")
+}
+```
+
+Use typed `Timeframe` values from `timeframe("1h")` when reading Secondary data:
+
+```rhai
+let h1_candle = market.candle(H1);
+let h1_history = market.candles(H1);
+```
+
+Optional Secondary context that is unavailable or stale returns `()` from
+`market.candle(tf)` and `market.candles(tf)`. Required Secondary context that is
+unavailable or stale blocks the Strategy Tick before `on_tick` is called.
+Accessing an unconfigured timeframe is a Strategy Error.
+
+## Strategy State
+
+Strategy State is runtime-owned, session-local memory for one strategy instance.
+It persists between Strategy Ticks in the same session/backtest, starts empty for
+a new session, and is not live-persistent across process restarts in v1. V1 state
+values are primitives only: int, float, bool, and string.
+
+```rhai
+fn on_tick(market, context) {
+    let seen = context.state.get("seen", 0);
+    context.state.set("seen", seen + 1);
+
+    decision::hold().with_reason("seen tick")
+}
+```
+
+Use matching primitive types per key; reading a key as a different primitive type
+is a Strategy Error.
+
+## Portfolio context
+
+Portfolio data is grouped under `context.portfolio`:
+
+```rhai
+let portfolio = context.portfolio;
+let position = portfolio.position;
+
+if position == () {
+    return decision::open_long(1.0);
+}
+
+if position.side == "Long" {
+    return decision::close_long().with_reason("exit long");
+}
+```
+
+`context.portfolio` is the runtime-local Portfolio Snapshot, not an external
+broker account snapshot.
+
+## Warmup
+
+Warmup is handled by the runtime before Strategy Ticks. The effective warmup is
+resolved from auto-detected indicator requirements, `strategy_config()` minimum
+warmup, and runtime configuration. During warmup, `on_tick` is not called and
+Strategy State is not mutated.
+
+Indicators can still return `()` when there is insufficient visible history, so
+keep explicit guards in strategy logic:
+
+```rhai
+let s = indicators::sma(market.candles(), 20);
+if s == () {
+    return decision::hold().with_reason("warming up");
+}
+```
+
+## Anchored / structure outputs
+
+`anchored_config()` is optional and returns a typed `AnchoredConfig`. Anchored
+outputs are market-derived and are read through `market`, not `context`.
+
+```rhai
 fn anchored_config() {
-    #{
-        detectors: [
-            #{ id: "p", kind: "pivot", left: PIVOT_LEFT, right: PIVOT_RIGHT },
-        ],
-        evaluators: [
-            #{
-                expose_as:    "resistance",
-                kind:         "trendline",
-                side:         "resistance",
-                pivot_source: "p",
-                pivot_buffer: PIVOT_BUFFER,
-                tolerance:    TOLERANCE,
-                min_touches:  MIN_TOUCHES,
-                max_lines:    1,
-            },
-        ],
-    }
+    anchored_config::new()
+        .with_detector(
+            pivot_detector::new("swing")
+                .with_left_bars(3)
+                .with_right_bars(3)
+        )
+        .with_evaluator(
+            anchored::trendline("resistance", "swing")
+                .with_side(pivot_side::high())
+                .with_pivot_buffer(6)
+                .with_tolerance(0.002)
+                .with_min_touches(3)
+                .with_max_lines(1)
+        )
 }
 
-fn on_tick(candles, context) {
-    let c = candles[1];
-    if c == () { return #{ signal: "HOLD" }; }
-
-    let lines = context.anchored("resistance");
-    let has_lines = type_of(lines) == "array" && lines.len() > 0;
-    if !has_lines {
-        return #{ signal: "HOLD", reason: "waiting for anchored fit" };
+fn on_tick(market, context) {
+    let lines = market.anchored("resistance");
+    if type_of(lines) == "array" && lines.len() > 0 {
+        let current_bar = market.candles().len() - 1;
+        let line = lines[0];
+        if market.candle().close > line.y_at(current_bar) {
+            return decision::open_long(1.0).with_reason("break above resistance");
+        }
     }
 
-    let line = lines[0];
-    if c.close > line.y_at(c.bar) && !context.has_position() {
-        return #{
-            signal: "BUY",
-            size: 0.5,
-            reason: "break above resistance",
-        };
-    }
-
-    #{ signal: "HOLD" }
+    decision::hold()
 }
 ```
-
-## Authoring conventions for this repo
-
-### 1. Always guard warmup explicitly
-
-Most indicator functions return `()` until enough history exists.
-
-```rhai
-let rsi = indicators::rsi(candles, 14);
-if rsi == () {
-    return #{ signal: "HOLD", reason: "warming up" };
-}
-```
-
-### 2. Prefer constants over magic numbers
-
-```rhai
-const RSI_PERIOD = 14;
-const OVERSOLD   = 30.0;
-```
-
-### 3. Return `reason` for meaningful actions
-
-Good `reason` strings make backtests and live runs much easier to inspect.
-
-### 4. Be explicit about position checks
-
-Use `context.has_position()` or `context.position == ()` before opening or closing.
-
-### 5. Use matching state types per key
-
-If you persist strategy state between ticks, keep each key either integer-based
-or float-based.
-
-```rhai
-let seen = context.state("seen", 0);
-context.set_state("seen", seen + 1);
-```
-
-```rhai
-let peak = context.state_f("peak", 0.0);
-if candles[1] != () && candles[1].close > peak {
-    context.set_state_f("peak", candles[1].close);
-}
-```
-
-### 6. Treat helper arrays as plain arrays
-
-`candles[1]` is 1-indexed and newest-first.
-
-`candles.closes()`, `opens()`, `highs()`, `lows()`, and `volumes()` return
-plain Rhai arrays, so they are 0-indexed. That means:
-
-```rhai
-candles[1].close == candles.closes()[0]
-```
-
-when data exists.
 
 ## Recommended starting points
 
-### `sma_cross.rhai`
+- `sma_cross.rhai` — rolling SMA crossover with entry risk parameters.
+- `min_loss.rhai` — SMA crossover plus primitive Strategy State.
+- `trendline_break.rhai` — typed anchored config and market-facing anchored outputs.
 
-Start here if you want:
-- rolling indicators only
-- simple long-only entry/exit logic
-- a small example with warmup guards and offset lookbacks
+## Legacy donor API is not current guidance
 
-### `trendline_break.rhai`
-
-Start here if you want:
-- anchored indicators
-- pivot-driven trendlines
-- event-driven breakout logic with stops and targets
-
-Other files in this folder may be experimental; the two strategies above are
-the maintained starter references.
-
-## When to open `REFERENCE.md`
-
-Open [`REFERENCE.md`](./REFERENCE.md) when you need:
-- exact `on_tick` return fields
-- the full `candles` and `context` API
-- the full list of currently exposed `indicators::...` functions
-- anchored detector/evaluator config details
-- edge cases and engine gotchas
+The old `fn on_tick(candles, context)` hook and legacy loose return maps such as
+`#{ signal: "BUY", size: 0.5 }` belong to the old engine donor material. They are
+not supported by the new Trading Runtime Strategy Handling path and should not be
+used for new strategies.

--- a/strategies/REFERENCE.md
+++ b/strategies/REFERENCE.md
@@ -1,20 +1,99 @@
-# Strategy reference
+# Typed Strategy Reference
 
-This file documents the current public Rhai API for strategies in this repo.
+This file documents the current strategy-author Rhai surface for the Trading
+Runtime typed Strategy Handling path. It intentionally describes the target
+runtime API, not the legacy `engine` API.
 
-It is intentionally limited to what strategy authors can use today through
-`on_tick`, `anchored_config`, `candles`, `context`, and `indicators::...`.
-Not every Rust helper in `indicators/` is exposed to Rhai.
+See [ADR 0005](../docs/adr/0005-use-typed-rhai-strategy-api.md) for the decision
+to use typed constructors and fluent methods instead of loose maps and magic
+strings.
 
-## Typed Trading Runtime Market View
+## Strategy file contract
 
-The new `trading-runtime` Rhai path uses typed hooks and values:
+Required hook:
+
+```rhai
+fn on_tick(market, context) {
+    decision::hold()
+}
+```
+
+Optional load-time hooks:
+
+```rhai
+fn strategy_config() {
+    strategy_config::new()
+}
+
+fn anchored_config() {
+    anchored_config::new()
+}
+```
+
+Notes:
+
+- Top-level code runs once when the strategy is loaded.
+- `on_tick(market, context)` is called only for Strategy Ticks after warmup and
+  required Secondary readiness checks pass.
+- `strategy_config()` may declare minimum warmup and Secondary-Timeframe
+  requirements/defaults.
+- `anchored_config()` may declare typed anchored/structure compute.
+- A strategy file may include an optional metadata comment such as
+  `// name: "sma_cross"`.
+
+## Decisions
+
+`on_tick` must return a typed `StrategyDecision` from `decision::*`.
+
+| Constructor | Meaning |
+| --- | --- |
+| `decision::hold()` | No strategy-driven position transition. |
+| `decision::open_long(quantity)` | Open a long position with quantity in asset units/contracts. |
+| `decision::close_long()` | Close an existing long position. |
+| `decision::open_short(quantity)` | Open a short position with quantity in asset units/contracts. |
+| `decision::close_short()` | Close an existing short position. |
+
+Fluent methods:
+
+| Method | Valid on | Effect |
+| --- | --- | --- |
+| `.with_stop_loss(price)` | opening decisions only | Adds a runtime-managed hard stop-loss entry risk parameter. |
+| `.with_take_profit(price)` | opening decisions only | Adds a runtime-managed hard take-profit entry risk parameter. |
+| `.with_reason(text)` | all decisions | Adds diagnostic context; no execution semantics. |
+
+Risk-parameter example:
+
+```rhai
+fn on_tick(market, context) {
+    let c = market.candle();
+
+    decision::open_long(1.0)
+        .with_stop_loss(c.close * 0.95)
+        .with_take_profit(c.close * 1.10)
+        .with_reason("risk managed long")
+}
+```
+
+Returning `()`, strings, arrays, or object maps is a Strategy Error.
+
+## Market View
+
+`market` exposes market data and market-derived structure outputs.
+
+Primary-Timeframe access:
+
+| Expression | Returns |
+| --- | --- |
+| `market.candle()` | current Primary candle |
+| `market.candles()` | Primary `CandleHistory` |
+| `market.candles()[1]` | current Primary candle |
+
+Secondary-Timeframe access uses typed `Timeframe` values:
 
 ```rhai
 const H1 = timeframe("1h");
 
 fn on_tick(market, context) {
-    let primary = market.candle();
     let h1 = market.candle(H1);
     let h1_history = market.candles(H1);
 
@@ -22,93 +101,21 @@ fn on_tick(market, context) {
         return decision::hold().with_reason("optional H1 unavailable");
     }
 
-    let h1_sma = indicators::sma(h1_history, 20);
     decision::hold()
 }
 ```
 
+Rules:
+
 - `market.candle()` / `market.candles()` read the Primary Timeframe.
-- `market.candle(tf)` / `market.candles(tf)` accept typed `Timeframe` values from `timeframe("1h")`.
-- Candle histories are 1-indexed and newest-first: `[1]` is the newest candle in that timeframe.
-- Optional Secondary-Timeframe context that is missing or stale returns `()` from both `market.candle(tf)` and `market.candles(tf)`.
-- Required unavailable Secondary-Timeframe context is blocked by runtime readiness before `on_tick` is called.
+- `market.candle(tf)` / `market.candles(tf)` read a configured Secondary
+  Timeframe.
+- Candle histories are 1-indexed and newest-first for strategy authors.
+- Out-of-range history indexes return `()`.
+- Optional unavailable/stale Secondary context returns `()`.
+- Required unavailable/stale Secondary context blocks the Strategy Tick before
+  `on_tick`.
 - Accessing an unconfigured timeframe is a Strategy Error.
-
-## Strategy file contract
-
-Every strategy must define:
-
-```rhai
-fn on_tick(candles, context) {
-    #{ signal: "HOLD" }   // or BUY / SELL / SHORT / COVER
-}
-```
-
-Optionally:
-
-```rhai
-fn anchored_config() {
-    #{ detectors: [...], evaluators: [...] }
-}
-```
-
-Notes:
-- Top-level code runs once at load time.
-- `anchored_config()` is called once at load time if present.
-- `on_tick(candles, context)` is called on each tick.
-- A strategy file may include an optional metadata comment such as:
-
-```rhai
-// name: "sma_cross"
-```
-
-## `on_tick` return shape
-
-`on_tick` must return a Rhai object map.
-
-| Field | Type | Required | Default | Notes |
-| --- | --- | --- | --- | --- |
-| `signal` | string | yes | — | `BUY`, `SELL`, `HOLD`, `SHORT`, `COVER` |
-| `size` | float | no | `1.0` for directional signals, `0.0` for `HOLD` | Portfolio fraction `0.0..=1.0` |
-| `stop_loss` | float | no | — | Hard stop price |
-| `take_profit` | float | no | — | Take-profit price |
-| `reason` | string | no | — | Logged alongside the trade |
-
-Example:
-
-```rhai
-return #{
-    signal: "BUY",
-    size: 0.5,
-    stop_loss: candles[1].low * 0.98,
-    take_profit: candles[1].close * 1.10,
-    reason: "fast crossed above slow",
-};
-```
-
-## `candles` API
-
-`candles` is a `CandleList`.
-
-### Indexing and helpers
-
-`candles[n]` is 1-indexed and newest-first.
-
-| Expression | Returns |
-| --- | --- |
-| `candles[1]` | current candle, or `()` if empty |
-| `candles[n]` | nth candle back, or `()` if out of range |
-| `candles.len()` | number of visible candles |
-| `candles.closes()` | plain Rhai array of closes, newest first |
-| `candles.opens()` | plain Rhai array of opens, newest first |
-| `candles.highs()` | plain Rhai array of highs, newest first |
-| `candles.lows()` | plain Rhai array of lows, newest first |
-| `candles.volumes()` | plain Rhai array of volumes, newest first |
-
-Important:
-- `candles[1]` is 1-indexed.
-- helper arrays like `candles.closes()` are plain Rhai arrays, so they are 0-indexed.
-- therefore `candles[1].close == candles.closes()[0]` when data exists.
 
 ### `Candle` fields and methods
 
@@ -121,64 +128,71 @@ Important:
 | `candle.volume` | float |
 | `candle.timestamp` | integer |
 | `candle.symbol` | string |
-| `candle.bar` | integer, absolute 0-based bar index |
+| `candle.timeframe` | `Timeframe` |
 | `candle.body()` | float |
 | `candle.range()` | float |
 
-## `context` API
-
-`context` is a `Context` wrapper with portfolio state, anchored outputs, and a
-small persistent key-value store.
-
-### Portfolio fields
+### `CandleHistory`
 
 | Expression | Returns |
 | --- | --- |
-| `context.balance` | cash balance |
-| `context.equity` | balance plus open-position value |
-| `context.trades_count` | number of closed trades so far |
-| `context.position` | `Position` or `()` |
-| `context.has_position()` | bool |
+| `history[n]` | nth candle back, 1-indexed newest-first, or `()` |
+| `history.len()` | number of visible candles |
 
-### Persistent state API
+## Indicators
 
-State persists between ticks for one strategy instance.
+Indicator bindings consume `CandleHistory` values from `market.candles(...)`.
+The typed runtime currently exposes:
 
-| Expression | Returns / effect |
+| Function | Returns |
 | --- | --- |
-| `context.state(name, default_int)` | stored integer-like value or the provided default |
-| `context.state_f(name, default_float)` | stored float-like value or the provided default |
-| `context.set_state(name, value)` | stores an integer-like value |
-| `context.set_state_f(name, value)` | stores a float-like value |
-
-Use matching read/write pairs per key.
+| `indicators::sma(history, period)` | `float` or `()` |
+| `indicators::sma(history, period, offset)` | `float` or `()` |
 
 Example:
 
 ```rhai
-let peak = context.state_f("peak_pnl", 0.0);
-if context.position != () {
-    let pnl = context.position.pnl();
-    if pnl > peak {
-        context.set_state_f("peak_pnl", pnl);
+fn on_tick(market, context) {
+    let fast = indicators::sma(market.candles(), 20);
+    let slow = indicators::sma(market.candles(), 50);
+
+    if fast == () || slow == () {
+        return decision::hold().with_reason("warming up");
+    }
+
+    if fast > slow {
+        decision::open_long(1.0).with_reason("fast above slow")
+    } else {
+        decision::hold()
     }
 }
 ```
 
-### Anchored output access
+Most history-dependent indicators return `()` until enough visible history is
+available. Keep explicit warmup guards in strategy code.
+
+## Strategy Context
+
+`context` is grouped. Market data is not exposed through `context`.
 
 | Expression | Returns |
 | --- | --- |
-| `context.anchored(name)` | anchored evaluator output, or `()` |
-| `context.last_pivot(id, "high"|"low")` | `PivotEvent` or `()` |
+| `context.portfolio` | runtime Portfolio Snapshot |
+| `context.state` | session-local Strategy State handle |
 
-`context.anchored(name)` returns:
-- `Array<TrendLine>` for `trendline`
-- `float` or `()` for `slope_between_pivots`
+### Portfolio Snapshot
 
-## `Position` API
+| Expression | Returns |
+| --- | --- |
+| `context.portfolio.realized_cash_balance` | realized cash balance |
+| `context.portfolio.equity` | current equity derived from Portfolio State and mark price |
+| `context.portfolio.completed_trades` | number of completed trades |
+| `context.portfolio.position` | `Position` or `()` |
 
-`context.position` exposes these fields and methods when non-empty:
+`context.portfolio` is runtime-local Portfolio State. It is not an external
+broker/account snapshot.
+
+### `Position`
 
 | Expression | Returns |
 | --- | --- |
@@ -188,103 +202,170 @@ if context.position != () {
 | `position.entry_time` | integer timestamp |
 | `position.stop_loss` | float or `()` |
 | `position.take_profit` | float or `()` |
-| `position.pnl()` | unrealized PnL at current price |
-| `position.value()` | current notional value at current price |
 
-## Anchored indicators
+Example:
 
-Anchored indicators are event-driven. They do not recompute every bar. They
-recompute when their source detector fires.
+```rhai
+fn on_tick(market, context) {
+    let position = context.portfolio.position;
 
-### `anchored_config()` shape
+    if position == () {
+        return decision::open_long(1.0).with_reason("enter");
+    }
+
+    if position.side == "Long" && market.candle().close < position.entry_price * 0.98 {
+        return decision::close_long().with_reason("strategy exit");
+    }
+
+    decision::hold()
+}
+```
+
+## Strategy State
+
+Strategy State is runtime-owned, session-local memory for one running strategy.
+It persists between Strategy Ticks in one runtime session and starts empty for a
+new session/backtest. V1 does not persist Strategy State across live process
+restarts.
+
+Primitive-only API:
+
+| Expression | Returns / effect |
+| --- | --- |
+| `context.state.get(name, default_int)` | stored int or default |
+| `context.state.get(name, default_float)` | stored float or default |
+| `context.state.get(name, default_bool)` | stored bool or default |
+| `context.state.get(name, default_string)` | stored string or default |
+| `context.state.set(name, value)` | stores an int, float, bool, or string |
+
+Use one primitive type per key. Reading a key as a different type is a Strategy
+Error.
+
+```rhai
+fn on_tick(market, context) {
+    let seen = context.state.get("seen", 0);
+    context.state.set("seen", seen + 1);
+
+    decision::hold().with_reason("seen tick")
+}
+```
+
+## Strategy Configuration
+
+`strategy_config()` returns a typed `StrategyConfig`.
+
+| Expression | Meaning |
+| --- | --- |
+| `strategy_config::new()` | Empty/default Strategy Configuration. |
+| `.with_minimum_warmup(n)` | Declares a global minimum warmup. |
+| `.with_secondary(secondary)` | Declares a Secondary-Timeframe requirement/default. |
+| `timeframe("1h")` | Parses and validates a typed `Timeframe`. |
+| `secondary::required(tf)` | Requires Secondary context before Strategy Ticks. |
+| `secondary::optional(tf)` | Allows Strategy Ticks when Secondary context is unavailable. |
+| `.with_max_missing_candles(n)` | Sets Secondary freshness tolerance. |
+
+```rhai
+const H1 = timeframe("1h");
+
+fn strategy_config() {
+    strategy_config::new()
+        .with_minimum_warmup(200)
+        .with_secondary(
+            secondary::required(H1)
+                .with_max_missing_candles(1)
+        )
+}
+```
+
+Strategy Configuration does not choose the Runtime Asset, Primary Timeframe,
+live/backtest mode, provider, broker, portfolio state, or execution semantics.
+Run Configuration remains authoritative.
+
+## Warmup
+
+The runtime resolves effective warmup from:
+
+```text
+max(auto_detected_warmup, strategy_config_minimum_warmup, runtime_minimum_warmup)
+```
+
+Warmup input rebuilds Market State/compute state but does not call `on_tick`,
+does not mutate Strategy State, and does not produce Strategy Decisions or
+Portfolio Transitions. In multi-timeframe runs, warmup must satisfy each
+configured timeframe in the Warmup Plan before Strategy Ticks begin.
+
+## Anchored / structure-aware compute
+
+`anchored_config()` returns a typed `AnchoredConfig`. Anchored outputs are read
+through `market`.
+
+### Config builders
+
+| Expression | Meaning |
+| --- | --- |
+| `anchored_config::new()` | Empty anchored config. |
+| `.with_detector(detector)` | Adds a detector. |
+| `.with_evaluator(evaluator)` | Adds an evaluator. |
+| `pivot_detector::new("id")` | Creates a pivot detector. |
+| `.with_left_bars(n)` / `.with_right_bars(n)` | Configures pivot confirmation windows. |
+| `anchored::trendline("name", "pivot_id")` | Creates a trendline evaluator. |
+| `.with_side(pivot_side::high())` | Resistance-style high-pivot trendline. |
+| `.with_side(pivot_side::low())` | Support-style low-pivot trendline. |
+| `.with_pivot_buffer(n)` | Number of pivots retained for fitting. |
+| `.with_tolerance(x)` | Touch tolerance. |
+| `.with_min_touches(n)` | Minimum touches; must be at least 3. |
+| `.with_max_lines(n)` | Maximum output lines. |
 
 ```rhai
 fn anchored_config() {
-    #{
-        detectors: [
-            #{ id: "p", kind: "pivot", left: 5, right: 5 },
-            #{ id: "lon", kind: "session", session: "LONDON",
-               start: "0900", end: "1700", tz: 2 },
-        ],
-        evaluators: [
-            #{
-                expose_as: "res",
-                kind: "trendline",
-                side: "resistance",
-                pivot_source: "p",
-                pivot_buffer: 6,
-                tolerance: 0.002,
-                min_touches: 3,
-                max_lines: 1,
-            },
-            #{
-                expose_as: "trend_slope",
-                kind: "slope_between_pivots",
-                pivot_source: "p",
-                side: "low",
-            },
-        ],
-    }
+    anchored_config::new()
+        .with_detector(
+            pivot_detector::new("swing")
+                .with_left_bars(3)
+                .with_right_bars(3)
+        )
+        .with_evaluator(
+            anchored::trendline("resistance", "swing")
+                .with_side(pivot_side::high())
+                .with_pivot_buffer(6)
+                .with_tolerance(0.002)
+                .with_min_touches(3)
+                .with_max_lines(1)
+        )
 }
 ```
 
-Validation happens at load time.
+### Output access
 
-Load-time errors include:
-- duplicate detector `id`
-- duplicate evaluator `expose_as`
-- unknown `pivot_source`
-- invalid parameter ranges
+| Expression | Returns |
+| --- | --- |
+| `market.anchored(name)` | anchored evaluator output, or `()` |
+| `market.last_pivot(detector_id, pivot_side::high())` | last high `PivotEvent`, or `()` |
+| `market.last_pivot(detector_id, pivot_side::low())` | last low `PivotEvent`, or `()` |
 
-### Supported detectors
+Currently supported anchored evaluator output:
 
-| `kind` | Required fields | Emits |
-| --- | --- | --- |
-| `pivot` | `id`, `left`, `right` | pivot high / low events |
-| `session` | `id`, `session`, `start`, `end`, `tz` | session open / close events |
+- `anchored::trendline(...)` returns `Array<TrendLine>` or `()` via
+  `market.anchored(name)`.
 
-Session values:
-- `"ASIA"`
-- `"LONDON"`
-- `"NEWYORK"`
-- `"NY"`
-- a numeric string that parses to `u8` for custom IDs
-
-### Supported evaluators
-
-| `kind` | Output | Required fields |
-| --- | --- | --- |
-| `trendline` | `Array<TrendLine>` | `expose_as`, `side`, `pivot_source`, `pivot_buffer`, `tolerance`, `min_touches`, `max_lines` |
-| `slope_between_pivots` | `float` or `()` | `expose_as`, `pivot_source`, `side` |
-
-`trendline.side` must be `"resistance"` or `"support"`.
-
-`slope_between_pivots.side` must be `"high"` or `"low"`.
-
-### Reading anchored outputs
+Example:
 
 ```rhai
-let lines = context.anchored("res");
-if type_of(lines) == "array" && lines.len() > 0 {
-    let line = lines[0];
-    let y = line.y_at(candles[1].bar);
-    if candles[1].close > y {
-        return #{ signal: "BUY", reason: "break above resistance" };
+fn on_tick(market, context) {
+    let lines = market.anchored("resistance");
+    if type_of(lines) == "array" && lines.len() > 0 {
+        let current_bar = market.candles().len() - 1;
+        let line = lines[0];
+        if market.candle().close > line.y_at(current_bar) {
+            return decision::open_long(1.0).with_reason("break above resistance");
+        }
     }
-}
 
-let slope = context.anchored("trend_slope");
-if type_of(slope) == "f64" && slope > 0.0 {
-    // trend filter
-}
-
-let p = context.last_pivot("p", "high");
-if p != () {
-    // use p.bar, p.price, p.volume, p.side
+    decision::hold()
 }
 ```
 
-### `TrendLine` API
+### `TrendLine`
 
 | Expression | Returns |
 | --- | --- |
@@ -296,7 +377,7 @@ if p != () {
 | `line.side` | `"resistance"` or `"support"` |
 | `line.y_at(bar)` | float |
 
-### `PivotEvent` API
+### `PivotEvent`
 
 | Expression | Returns |
 | --- | --- |
@@ -305,153 +386,9 @@ if p != () {
 | `pivot.volume` | float |
 | `pivot.side` | `"high"` or `"low"` |
 
-### Tick semantics
+## Legacy donor API is not supported here
 
-1. A new candle arrives.
-2. Detectors run.
-3. Evaluators recompute only if their source detector fired this tick.
-4. `on_tick` sees the current anchored outputs.
-5. Broken trendlines are pruned after `on_tick`, so the break bar still sees them and the next tick does not.
-
-That means breakout detection should compare the current candle against the
-current line value on the same bar.
-
-## `indicators::...` API
-
-All indicator functions below are currently exposed to Rhai.
-
-Unless noted otherwise, indicators return `()` when there is insufficient data.
-
-### Trend
-
-| Function | Returns |
-| --- | --- |
-| `indicators::sma(candles, period)` | `float` or `()` |
-| `indicators::sma(candles, period, offset)` | `float` or `()` |
-| `indicators::ema(candles, period)` | `float` or `()` |
-| `indicators::ema(candles, period, offset)` | `float` or `()` |
-| `indicators::dema(candles, period)` | `float` or `()` |
-| `indicators::dema(candles, period, offset)` | `float` or `()` |
-| `indicators::tema(candles, period)` | `float` or `()` |
-| `indicators::tema(candles, period, offset)` | `float` or `()` |
-| `indicators::macd(candles, fast, slow, signal)` | `#{ line, signal, histogram }` or `()` |
-| `indicators::macd(candles, fast, slow, signal, offset)` | `#{ line, signal, histogram }` or `()` |
-| `indicators::sar(candles, step, max)` | `#{ value, side, reversed, ep, af }` or `()` |
-| `indicators::sar(candles, step, max, offset)` | `#{ value, side, reversed, ep, af }` or `()` |
-| `indicators::adx(candles, period)` | `#{ adx, plus_di, minus_di }` or `()` |
-| `indicators::adx(candles, period, offset)` | `#{ adx, plus_di, minus_di }` or `()` |
-| `indicators::ichimoku(candles)` | `#{ tenkan, kijun, span_a, span_b, chikou }` or `()` |
-| `indicators::ichimoku(candles, offset)` | `#{ tenkan, kijun, span_a, span_b, chikou }` or `()` |
-
-### Momentum
-
-| Function | Returns |
-| --- | --- |
-| `indicators::rsi(candles, period)` | `float` or `()` |
-| `indicators::rsi(candles, period, offset)` | `float` or `()` |
-| `indicators::cci(candles, period)` | `float` or `()` |
-| `indicators::cci(candles, period, offset)` | `float` or `()` |
-| `indicators::stochastic_fast(candles, period)` | `#{ k, d }` or `()` |
-| `indicators::stochastic_fast(candles, period, offset)` | `#{ k, d }` or `()` |
-| `indicators::stochastic_slow(candles, period)` | `#{ k, d }` or `()` |
-| `indicators::stochastic_slow(candles, period, offset)` | `#{ k, d }` or `()` |
-| `indicators::stochastic_full(candles, period)` | `#{ k, d }` or `()` (k_smooth=3, d_period=3) |
-| `indicators::stochastic_full(candles, period, k_smooth)` | `#{ k, d }` or `()` |
-| `indicators::stochastic_full(candles, period, k_smooth, d_period)` | `#{ k, d }` or `()` |
-| `indicators::williams_r(candles, period)` | `float` or `()` |
-| `indicators::williams_r(candles, period, offset)` | `float` or `()` |
-| `indicators::roc(candles, period)` | `float` or `()` |
-| `indicators::roc(candles, period, offset)` | `float` or `()` |
-
-### Volatility
-
-| Function | Returns |
-| --- | --- |
-| `indicators::bollinger(candles, period, std_dev)` | `#{ upper, middle, lower }` or `()` |
-| `indicators::bollinger(candles, period, std_dev, offset)` | `#{ upper, middle, lower }` or `()` |
-| `indicators::atr(candles, period)` | `float` or `()` |
-| `indicators::atr(candles, period, offset)` | `float` or `()` |
-| `indicators::keltner(candles, period, multiplier)` | `#{ upper, middle, lower }` or `()` |
-| `indicators::keltner(candles, period, multiplier, offset)` | `#{ upper, middle, lower }` or `()` |
-
-### Volume
-
-| Function | Returns |
-| --- | --- |
-| `indicators::obv(candles)` | `float` or `()` |
-| `indicators::obv(candles, offset)` | `float` or `()` |
-| `indicators::vwap(candles)` | `float` or `()` |
-| `indicators::vwap(candles, offset)` | `float` or `()` |
-| `indicators::mfi(candles, period)` | `float` or `()` |
-| `indicators::mfi(candles, period, offset)` | `float` or `()` |
-| `indicators::volume_profile(candles, buckets)` | `Array<#{ price, volume }>` or `()` |
-| `indicators::volume_profile(candles, buckets, offset)` | `Array<#{ price, volume }>` or `()` |
-
-### Support / resistance and geometry
-
-| Function | Returns |
-| --- | --- |
-| `indicators::pivot_points(candles)` | `#{ pp, r1, r2, r3, s1, s2, s3 }` or `()` |
-| `indicators::pivot_points(candles, offset)` | `#{ pp, r1, r2, r3, s1, s2, s3 }` or `()` |
-| `indicators::fibonacci(candles, low, high)` | `Array<float>` |
-| `indicators::slope(candles, period)` | `float` or `()` |
-| `indicators::slope(candles, period, offset)` | `float` or `()` |
-
-## Public API boundary
-
-This reference is about the Rhai authoring surface, not every Rust helper in
-`indicators/`.
-
-Examples of Rust helpers that exist today but are not exposed directly to Rhai:
-- `ema_series`
-- `atr_series`
-- `ichimoku_custom`
-
-`fibonacci` is the one public indicator without an offset overload because its
-result depends only on the explicit `low` and `high` arguments, not on candle
-history.
-
-Likewise, the anchored Rust module contains internal event types that are not
-currently configurable from strategy code. The public strategy surface today is:
-- detectors: `pivot`, `session`
-- evaluators: `trendline`, `slope_between_pivots`
-
-## Engine gotchas
-
-### Warmup
-
-Always expect warmup.
-
-```rhai
-let s = indicators::sma(candles, 20);
-if s == () {
-    return #{ signal: "HOLD", reason: "warming up" };
-}
-```
-
-The backtester tries to infer warmup from `indicators::*` calls and top-level
-constants. If it cannot resolve periods, it falls back to `200` bars.
-
-### Expression complexity
-
-Large nested return maps can trip Rhai's expression complexity limit.
-
-```rhai
-// Better
-let tp = candles[1].close * 1.10;
-return #{
-    signal: "BUY",
-    take_profit: tp,
-    reason: "break above resistance",
-};
-```
-
-### Use top-level constants for strategy parameters
-
-Top-level `const` values run once at load time and are visible to both
-`anchored_config()` and `on_tick()`.
-
-```rhai
-const FAST = 20;
-const SLOW = 50;
-```
+The old hook `fn on_tick(candles, context)` and loose return maps such as
+`#{ signal: "BUY", size: 0.5 }` are legacy old-engine donor material only. They
+are not the target Strategy Handling API and are not compatibility-mapped by the
+Trading Runtime typed Rhai path.

--- a/strategies/REFERENCE.md
+++ b/strategies/REFERENCE.md
@@ -6,6 +6,34 @@ It is intentionally limited to what strategy authors can use today through
 `on_tick`, `anchored_config`, `candles`, `context`, and `indicators::...`.
 Not every Rust helper in `indicators/` is exposed to Rhai.
 
+## Typed Trading Runtime Market View
+
+The new `trading-runtime` Rhai path uses typed hooks and values:
+
+```rhai
+const H1 = timeframe("1h");
+
+fn on_tick(market, context) {
+    let primary = market.candle();
+    let h1 = market.candle(H1);
+    let h1_history = market.candles(H1);
+
+    if h1 == () || h1_history == () {
+        return decision::hold().with_reason("optional H1 unavailable");
+    }
+
+    let h1_sma = indicators::sma(h1_history, 20);
+    decision::hold()
+}
+```
+
+- `market.candle()` / `market.candles()` read the Primary Timeframe.
+- `market.candle(tf)` / `market.candles(tf)` accept typed `Timeframe` values from `timeframe("1h")`.
+- Candle histories are 1-indexed and newest-first: `[1]` is the newest candle in that timeframe.
+- Optional Secondary-Timeframe context that is missing or stale returns `()` from both `market.candle(tf)` and `market.candles(tf)`.
+- Required unavailable Secondary-Timeframe context is blocked by runtime readiness before `on_tick` is called.
+- Accessing an unconfigured timeframe is a Strategy Error.
+
 ## Strategy file contract
 
 Every strategy must define:

--- a/strategies/min_loss.rhai
+++ b/strategies/min_loss.rhai
@@ -1,49 +1,54 @@
-// name: "sma_cross_pnl"
-// SMA Crossover Strategy with Trailing Stop (via State API)
-// BUY  when the fast SMA crosses above the slow SMA
-// SELL when the fast SMA crosses below the slow SMA OR trailing stop hit
+// name: "sma_cross_state"
+// Typed Runtime SMA crossover strategy with primitive Strategy State.
+// Tracks the highest close seen while long and closes the long if price falls
+// more than TRAIL_PCT from that session-local peak.
 
 const FAST = 20;
-const SLOW = 20;
+const SLOW = 50;
+const QUANTITY = 1.0;
+const TRAIL_PCT = 0.05;
 
-fn on_tick(candles, context) {
-    // Trailing stop via state API
-    // if context.has_position() {
-    //     let pnl = context.position.pnl();
-    //     let peak = context.state_f("peak_pnl", 0.0);
-    //     if pnl > peak { context.set_state_f("peak_pnl", pnl); }
-    //     if pnl < 0.9 * peak {
-    //         return #{ signal: "SELL", reason: "trailing stop" };
-    //     }
-    // }
+fn strategy_config() {
+    strategy_config::new().with_minimum_warmup(SLOW + 1)
+}
 
-    let fast      = indicators::ema(candles, FAST);
+fn on_tick(market, context) {
+    let candles = market.candles();
+    let current = market.candle();
+    let position = context.portfolio.position;
+
+    if position != () && position.side == "Long" {
+        let peak = context.state.get("peak_close", current.close);
+        let next_peak = if current.close > peak { current.close } else { peak };
+        context.state.set("peak_close", next_peak);
+
+        if current.close < next_peak * (1.0 - TRAIL_PCT) {
+            return decision::close_long().with_reason("trailing close below peak");
+        }
+    } else {
+        context.state.set("peak_close", current.close);
+    }
+
+    let fast      = indicators::sma(candles, FAST);
     let slow      = indicators::sma(candles, SLOW);
-    let fast_prev = indicators::ema(candles, FAST, 1);
+    let fast_prev = indicators::sma(candles, FAST, 1);
     let slow_prev = indicators::sma(candles, SLOW, 1);
 
-    // Not enough data yet
     if fast == () || slow == () || fast_prev == () || slow_prev == () {
-        return #{ signal: "HOLD", reason: "warming up" };
+        return decision::hold().with_reason("warming up");
     }
 
     let crossed_up   = fast_prev <= slow_prev && fast > slow;
     let crossed_down = fast_prev >= slow_prev && fast < slow;
 
-    if crossed_up && context.position == () {
-        return #{
-            signal:      "BUY",
-            size:        0.5,
-            reason:      `SMA${FAST} crossed above SMA${SLOW}`,
-        };
+    if crossed_up && position == () {
+        context.state.set("peak_close", current.close);
+        return decision::open_long(QUANTITY).with_reason("fast SMA crossed above slow SMA");
     }
 
-    if crossed_down && context.position != () {
-        return #{
-            signal: "SELL",
-            reason: `SMA${FAST} crossed below SMA${SLOW}`,
-        };
+    if crossed_down && position != () && position.side == "Long" {
+        return decision::close_long().with_reason("fast SMA crossed below slow SMA");
     }
 
-    #{ signal: "HOLD" }
+    decision::hold()
 }

--- a/strategies/sma_cross.rhai
+++ b/strategies/sma_cross.rhai
@@ -1,41 +1,43 @@
 // name: "sma_cross"
-// SMA Crossover Strategy
-// BUY  when the fast SMA crosses above the slow SMA
-// SELL when the fast SMA crosses below the slow SMA
+// Typed Runtime SMA crossover strategy.
+// Opens a long position when the fast SMA crosses above the slow SMA and closes
+// it when the fast SMA crosses back below the slow SMA.
 
 const FAST = 50;
 const SLOW = 200;
+const QUANTITY = 1.0;
 
-fn on_tick(candles, context) {
+fn strategy_config() {
+    strategy_config::new().with_minimum_warmup(SLOW + 1)
+}
+
+fn on_tick(market, context) {
+    let candles = market.candles();
+    let current = market.candle();
+
     let fast      = indicators::sma(candles, FAST);
     let slow      = indicators::sma(candles, SLOW);
     let fast_prev = indicators::sma(candles, FAST, 1);
     let slow_prev = indicators::sma(candles, SLOW, 1);
 
-    // Not enough data yet
     if fast == () || slow == () || fast_prev == () || slow_prev == () {
-        return #{ signal: "HOLD", reason: "warming up" };
+        return decision::hold().with_reason("warming up");
     }
 
     let crossed_up   = fast_prev <= slow_prev && fast > slow;
     let crossed_down = fast_prev >= slow_prev && fast < slow;
+    let position = context.portfolio.position;
 
-    if crossed_up && context.position == () {
-        return #{
-            signal:      "BUY",
-            size:        0.5,
-            stop_loss:   candles[1].low * 0.98,
-            take_profit: candles[1].close * 1.10,
-            reason:      `SMA${FAST} crossed above SMA${SLOW}`,
-        };
+    if crossed_up && position == () {
+        return decision::open_long(QUANTITY)
+            .with_stop_loss(current.low * 0.98)
+            .with_take_profit(current.close * 1.10)
+            .with_reason("fast SMA crossed above slow SMA");
     }
 
-    if crossed_down && context.position != () {
-        return #{
-            signal: "SELL",
-            reason: `SMA${FAST} crossed below SMA${SLOW}`,
-        };
+    if crossed_down && position != () && position.side == "Long" {
+        return decision::close_long().with_reason("fast SMA crossed below slow SMA");
     }
 
-    #{ signal: "HOLD" }
+    decision::hold()
 }

--- a/strategies/trendline_break.rhai
+++ b/strategies/trendline_break.rhai
@@ -1,116 +1,50 @@
 // name: "trendline_break"
-// Trendline Breakout Strategy
-//
-// Uses anchored indicators:
-//   - Pivot detector (left=5, right=5) feeds a 6-slot ring of pivot highs / lows.
-//   - Trendline evaluators fit 3+-touch resistance and support lines on the ring.
-//
-// Entry:
-//   BUY   when close breaks above the top resistance line.
-//   SHORT when close breaks below the top support line.
-// Exit:
-//   Managed via stop_loss (opposite line) and take_profit (risk:reward 2:1).
-//
-// The anchored pipeline only recomputes on each new confirmed pivot, so
-// engine cost is event-driven, not per-bar.
+// Typed Runtime trendline breakout strategy.
+// Uses anchored pivot-derived resistance exposed through `market`.
 
-const PIVOT_LEFT     = 5;
-const PIVOT_RIGHT    = 5;
-const PIVOT_BUFFER   = 6;
-const TOLERANCE      = 0.002;  // 0.2% touch tolerance
-const MIN_TOUCHES    = 3;
-const MAX_LINES      = 1;
-const RR_RATIO       = 2.0;
+const PIVOT_LEFT = 5;
+const PIVOT_RIGHT = 5;
+const PIVOT_BUFFER = 6;
+const TOLERANCE = 0.002;
+const MIN_TOUCHES = 3;
+const MAX_LINES = 1;
+const QUANTITY = 1.0;
 
 fn anchored_config() {
-    #{
-        detectors: [
-            #{ id: "p", kind: "pivot", left: PIVOT_LEFT, right: PIVOT_RIGHT },
-        ],
-        evaluators: [
-            #{
-                expose_as:    "resistance",
-                kind:         "trendline",
-                side:         "resistance",
-                pivot_source: "p",
-                pivot_buffer: PIVOT_BUFFER,
-                tolerance:    TOLERANCE,
-                min_touches:  MIN_TOUCHES,
-                max_lines:    MAX_LINES,
-            },
-            #{
-                expose_as:    "support",
-                kind:         "trendline",
-                side:         "support",
-                pivot_source: "p",
-                pivot_buffer: PIVOT_BUFFER,
-                tolerance:    TOLERANCE,
-                min_touches:  MIN_TOUCHES,
-                max_lines:    MAX_LINES,
-            },
-        ],
-    }
+    anchored_config::new()
+        .with_detector(
+            pivot_detector::new("p")
+                .with_left_bars(PIVOT_LEFT)
+                .with_right_bars(PIVOT_RIGHT)
+        )
+        .with_evaluator(
+            anchored::trendline("resistance", "p")
+                .with_side(pivot_side::high())
+                .with_pivot_buffer(PIVOT_BUFFER)
+                .with_tolerance(TOLERANCE)
+                .with_min_touches(MIN_TOUCHES)
+                .with_max_lines(MAX_LINES)
+        )
 }
 
-fn on_tick(candles, context) {
-    let c   = candles[1];
-    if c == () { return #{ signal: "HOLD" }; }
+fn on_tick(market, context) {
+    let c = market.candle();
+    let current_bar = market.candles().len() - 1;
+    let lines = market.anchored("resistance");
+    let has_lines = type_of(lines) == "array" && lines.len() > 0;
+    let position = context.portfolio.position;
 
-    let res = context.anchored("resistance");
-    let sup = context.anchored("support");
-
-    let has_res = type_of(res) == "array" && res.len() > 0;
-    let has_sup = type_of(sup) == "array" && sup.len() > 0;
-
-    // Exit logic: if in a position, close on opposite break.
-    if context.position != () {
-        if context.position.side == "Long" && has_sup && c.close < sup[0].y_at(c.bar) {
-            return #{ signal: "SELL", reason: "support broken — long exit" };
-        }
-        if context.position.side == "Short" && has_res && c.close > res[0].y_at(c.bar) {
-            return #{ signal: "COVER", reason: "resistance broken — short exit" };
-        }
-        return #{ signal: "HOLD" };
+    if position != () {
+        return decision::hold();
     }
 
-    // Entry logic: breakout in either direction.
-    if has_res {
-        let r    = res[0];
-        let r_y  = r.y_at(c.bar);
-        if c.close > r_y && has_sup {
-            let s_y  = sup[0].y_at(c.bar);
-            let risk = c.close - s_y;
-            if risk > 0.0 {
-                let tp = c.close + risk * RR_RATIO;
-                return #{
-                    signal:      "BUY",
-                    size:        0.5,
-                    stop_loss:   s_y,
-                    take_profit: tp,
-                    reason:      "break above resistance",
-                };
-            }
+    if has_lines {
+        let line = lines[0];
+        let y = line.y_at(current_bar);
+        if c.close > y {
+            return decision::open_long(QUANTITY).with_reason("break above resistance");
         }
     }
 
-    if has_sup {
-        let s    = sup[0];
-        let s_y  = s.y_at(c.bar);
-        if c.close < s_y && has_res {
-            let r_y  = res[0].y_at(c.bar);
-            let risk = r_y - c.close;
-            if risk > 0.0 {
-                let tp = c.close - risk * RR_RATIO;
-                return #{
-                    signal:      "SHORT",
-                    size:        0.5,
-                    stop_loss:   r_y,
-                    take_profit: tp,
-                    reason:      "break below support",
-                };
-            }
-        }
-    }
-
-    #{ signal: "HOLD" }
+    decision::hold()
 }

--- a/trading-runtime/Cargo.toml
+++ b/trading-runtime/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+rhai   = { workspace = true }
 shared = { path = "../shared" }

--- a/trading-runtime/Cargo.toml
+++ b/trading-runtime/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rhai   = { workspace = true }
-shared = { path = "../shared" }
+indicators = { path = "../indicators" }
+rhai       = { workspace = true }
+shared     = { path = "../shared" }

--- a/trading-runtime/src/anchored.rs
+++ b/trading-runtime/src/anchored.rs
@@ -1,0 +1,465 @@
+//! Runtime-owned anchored/structure-aware compute for Rhai Strategy Handling.
+//!
+//! The typed Rhai `anchored_config()` hook lowers to [`AnchoredConfiguration`].
+//! Runtime market input then updates [`AnchoredRuntime`] from runtime-owned
+//! [`MarketState`](crate::MarketState) history; strategy-facing outputs are read
+//! through Market View bindings, not Strategy Context.
+
+use indicators::anchored::{
+    detectors::{PivotDetector, PivotKind},
+    evaluators::{TrendLine, TrendlineEvaluator, TrendlineInvalidator, TrendlineSide},
+    AnchorEvent, Invalidator, RollingDetector, SegmentState,
+};
+use shared::Candle;
+use std::collections::{HashMap, HashSet};
+
+/// Typed strategy-declared anchored compute configuration.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AnchoredConfiguration {
+    detectors: Vec<AnchoredDetectorSpec>,
+    evaluators: Vec<AnchoredEvaluatorSpec>,
+}
+
+impl AnchoredConfiguration {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_detector(mut self, detector: PivotDetectorConfiguration) -> Self {
+        self.detectors.push(AnchoredDetectorSpec::Pivot {
+            id: detector.id,
+            left_bars: detector.left_bars,
+            right_bars: detector.right_bars,
+        });
+        self
+    }
+
+    pub fn with_evaluator(mut self, evaluator: AnchoredEvaluatorConfiguration) -> Self {
+        self.evaluators.push(AnchoredEvaluatorSpec::Trendline {
+            expose_as: evaluator.expose_as,
+            pivot_source: evaluator.pivot_source,
+            side: evaluator.side.as_trendline_side(),
+            pivot_buffer: evaluator.pivot_buffer,
+            tolerance: evaluator.tolerance,
+            min_touches: evaluator.min_touches,
+            max_lines: evaluator.max_lines,
+        });
+        self
+    }
+
+    pub fn detectors(&self) -> &[AnchoredDetectorSpec] {
+        &self.detectors
+    }
+
+    pub fn evaluators(&self) -> &[AnchoredEvaluatorSpec] {
+        &self.evaluators
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.detectors.is_empty() && self.evaluators.is_empty()
+    }
+
+    pub fn validate(&self) -> Result<(), AnchoredConfigurationError> {
+        let mut detector_ids = HashSet::new();
+        for detector in &self.detectors {
+            if detector.id().is_empty() {
+                return Err(AnchoredConfigurationError::new(
+                    "detector id must not be empty",
+                ));
+            }
+            if !detector_ids.insert(detector.id().to_string()) {
+                return Err(AnchoredConfigurationError::new(format!(
+                    "duplicate detector id `{}`",
+                    detector.id()
+                )));
+            }
+        }
+
+        let mut expose_names = HashSet::new();
+        for evaluator in &self.evaluators {
+            if evaluator.expose_as().is_empty() {
+                return Err(AnchoredConfigurationError::new(
+                    "evaluator expose name must not be empty",
+                ));
+            }
+            if !expose_names.insert(evaluator.expose_as().to_string()) {
+                return Err(AnchoredConfigurationError::new(format!(
+                    "duplicate evaluator expose name `{}`",
+                    evaluator.expose_as()
+                )));
+            }
+            if !detector_ids.contains(evaluator.pivot_source()) {
+                return Err(AnchoredConfigurationError::new(format!(
+                    "evaluator `{}` references unknown pivot detector `{}`",
+                    evaluator.expose_as(),
+                    evaluator.pivot_source()
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Typed pivot detector spec supported by the first anchored path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AnchoredDetectorSpec {
+    Pivot {
+        id: String,
+        left_bars: usize,
+        right_bars: usize,
+    },
+}
+
+impl AnchoredDetectorSpec {
+    pub fn id(&self) -> &str {
+        match self {
+            Self::Pivot { id, .. } => id,
+        }
+    }
+}
+
+/// Typed evaluator spec supported by the first anchored path.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AnchoredEvaluatorSpec {
+    Trendline {
+        expose_as: String,
+        pivot_source: String,
+        side: TrendlineSide,
+        pivot_buffer: usize,
+        tolerance: f64,
+        min_touches: u32,
+        max_lines: usize,
+    },
+}
+
+impl AnchoredEvaluatorSpec {
+    pub fn expose_as(&self) -> &str {
+        match self {
+            Self::Trendline { expose_as, .. } => expose_as,
+        }
+    }
+
+    pub fn pivot_source(&self) -> &str {
+        match self {
+            Self::Trendline { pivot_source, .. } => pivot_source,
+        }
+    }
+}
+
+/// Builder returned by `pivot_detector::new(...)` in Rhai.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PivotDetectorConfiguration {
+    id: String,
+    left_bars: usize,
+    right_bars: usize,
+}
+
+impl PivotDetectorConfiguration {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            left_bars: 2,
+            right_bars: 2,
+        }
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn with_left_bars(mut self, left_bars: usize) -> Self {
+        self.left_bars = left_bars;
+        self
+    }
+
+    pub fn with_right_bars(mut self, right_bars: usize) -> Self {
+        self.right_bars = right_bars;
+        self
+    }
+}
+
+/// Builder returned by `anchored::trendline(...)` in Rhai.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AnchoredEvaluatorConfiguration {
+    expose_as: String,
+    pivot_source: String,
+    side: PivotSide,
+    pivot_buffer: usize,
+    tolerance: f64,
+    min_touches: u32,
+    max_lines: usize,
+}
+
+impl AnchoredEvaluatorConfiguration {
+    pub fn trendline(expose_as: impl Into<String>, pivot_source: impl Into<String>) -> Self {
+        Self {
+            expose_as: expose_as.into(),
+            pivot_source: pivot_source.into(),
+            side: PivotSide::High,
+            pivot_buffer: 6,
+            tolerance: 0.01,
+            min_touches: 3,
+            max_lines: 1,
+        }
+    }
+
+    pub fn expose_as(&self) -> &str {
+        &self.expose_as
+    }
+
+    pub fn pivot_source(&self) -> &str {
+        &self.pivot_source
+    }
+
+    pub fn with_side(mut self, side: PivotSide) -> Self {
+        self.side = side;
+        self
+    }
+
+    pub fn with_pivot_buffer(mut self, pivot_buffer: usize) -> Self {
+        self.pivot_buffer = pivot_buffer;
+        self
+    }
+
+    pub fn with_tolerance(mut self, tolerance: f64) -> Self {
+        self.tolerance = tolerance;
+        self
+    }
+
+    pub fn with_min_touches(mut self, min_touches: u32) -> Self {
+        self.min_touches = min_touches;
+        self
+    }
+
+    pub fn with_max_lines(mut self, max_lines: usize) -> Self {
+        self.max_lines = max_lines;
+        self
+    }
+}
+
+/// Typed pivot side used by anchored config and `market.last_pivot(...)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PivotSide {
+    High,
+    Low,
+}
+
+impl PivotSide {
+    pub fn high() -> Self {
+        Self::High
+    }
+
+    pub fn low() -> Self {
+        Self::Low
+    }
+
+    fn as_trendline_side(self) -> TrendlineSide {
+        match self {
+            Self::High => TrendlineSide::Resistance,
+            Self::Low => TrendlineSide::Support,
+        }
+    }
+}
+
+/// Load-time validation error for typed anchored config.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnchoredConfigurationError {
+    message: String,
+}
+
+impl AnchoredConfigurationError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for AnchoredConfigurationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "anchored_config: {}", self.message)
+    }
+}
+
+impl std::error::Error for AnchoredConfigurationError {}
+
+/// Output of one anchored evaluator, keyed by its exposed name.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AnchoredOutput {
+    Trendlines(Vec<TrendLine>),
+}
+
+/// Latest market-derived anchored outputs.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AnchoredOutputs {
+    pub values: HashMap<String, AnchoredOutput>,
+    pub last_pivot_high: HashMap<String, PivotEvent>,
+    pub last_pivot_low: HashMap<String, PivotEvent>,
+}
+
+/// Pivot event exposed through Market View.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PivotEvent {
+    pub bar: u64,
+    pub price: f64,
+    pub volume: f64,
+    pub side: PivotSide,
+}
+
+struct DetectorState {
+    id: String,
+    detector: Box<dyn RollingDetector + Send + Sync>,
+    ring: SegmentState<AnchorEvent>,
+    fired_this_tick: bool,
+}
+
+/// Runtime-owned anchored compute state.
+pub struct AnchoredRuntime {
+    detectors: Vec<DetectorState>,
+    evaluators: Vec<AnchoredEvaluatorSpec>,
+    active_trendlines: HashMap<String, Vec<(TrendLine, TrendlineInvalidator)>>,
+    outputs: AnchoredOutputs,
+}
+
+impl AnchoredRuntime {
+    pub fn from_config(config: &AnchoredConfiguration) -> Result<Self, AnchoredConfigurationError> {
+        config.validate()?;
+
+        let mut ring_caps: HashMap<String, usize> = HashMap::new();
+        for evaluator in &config.evaluators {
+            match evaluator {
+                AnchoredEvaluatorSpec::Trendline {
+                    pivot_source,
+                    pivot_buffer,
+                    ..
+                } => {
+                    let entry = ring_caps.entry(pivot_source.clone()).or_insert(1);
+                    *entry = (*entry).max(*pivot_buffer);
+                }
+            }
+        }
+
+        let mut detectors = Vec::with_capacity(config.detectors.len());
+        for detector in &config.detectors {
+            match detector {
+                AnchoredDetectorSpec::Pivot {
+                    id,
+                    left_bars,
+                    right_bars,
+                } => {
+                    detectors.push(DetectorState {
+                        id: id.clone(),
+                        detector: Box::new(PivotDetector::new(
+                            *left_bars,
+                            *right_bars,
+                            PivotKind::Both,
+                        )),
+                        ring: SegmentState::new((*ring_caps.get(id).unwrap_or(&6)).max(1)),
+                        fired_this_tick: false,
+                    });
+                }
+            }
+        }
+
+        Ok(Self {
+            detectors,
+            evaluators: config.evaluators.clone(),
+            active_trendlines: HashMap::new(),
+            outputs: AnchoredOutputs::default(),
+        })
+    }
+
+    pub fn on_market_input_accepted(&mut self, candle: &Candle, history: &[Candle]) {
+        let Some(bar) = history.len().checked_sub(1).map(|bar| bar as u64) else {
+            return;
+        };
+
+        self.tick_primary(candle, bar, history);
+    }
+
+    pub fn outputs(&self) -> &AnchoredOutputs {
+        &self.outputs
+    }
+
+    fn tick_primary(&mut self, candle: &Candle, bar: u64, candles: &[Candle]) {
+        for detector in &mut self.detectors {
+            detector.fired_this_tick = false;
+            if let Some(event) = detector.detector.on_candle(candle, bar) {
+                match event {
+                    AnchorEvent::PivotHigh { bar, price, volume } => {
+                        self.outputs.last_pivot_high.insert(
+                            detector.id.clone(),
+                            PivotEvent {
+                                bar,
+                                price,
+                                volume,
+                                side: PivotSide::High,
+                            },
+                        );
+                    }
+                    AnchorEvent::PivotLow { bar, price, volume } => {
+                        self.outputs.last_pivot_low.insert(
+                            detector.id.clone(),
+                            PivotEvent {
+                                bar,
+                                price,
+                                volume,
+                                side: PivotSide::Low,
+                            },
+                        );
+                    }
+                    _ => {}
+                }
+                detector.ring.push(event);
+                detector.fired_this_tick = true;
+            }
+        }
+
+        for evaluator in &self.evaluators {
+            match evaluator {
+                AnchoredEvaluatorSpec::Trendline {
+                    expose_as,
+                    pivot_source,
+                    side,
+                    tolerance,
+                    min_touches,
+                    max_lines,
+                    ..
+                } => {
+                    let Some(detector) = self
+                        .detectors
+                        .iter()
+                        .find(|detector| detector.id == *pivot_source)
+                    else {
+                        continue;
+                    };
+
+                    if detector.fired_this_tick {
+                        let fitter =
+                            TrendlineEvaluator::new(*side, *tolerance, *min_touches, *max_lines);
+                        let fresh = fitter.fit(&detector.ring, candles, 0, bar);
+                        let paired = fresh
+                            .iter()
+                            .map(|line| (*line, TrendlineInvalidator(*line)))
+                            .collect();
+                        self.active_trendlines.insert(expose_as.clone(), paired);
+                    }
+
+                    let lines = self
+                        .active_trendlines
+                        .get(expose_as)
+                        .map(|lines| lines.iter().map(|(line, _)| *line).collect())
+                        .unwrap_or_default();
+                    self.outputs
+                        .values
+                        .insert(expose_as.clone(), AnchoredOutput::Trendlines(lines));
+                }
+            }
+        }
+
+        for lines in self.active_trendlines.values_mut() {
+            lines.retain(|(_, invalidator)| invalidator.still_valid(candle, bar));
+        }
+    }
+}

--- a/trading-runtime/src/events.rs
+++ b/trading-runtime/src/events.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     ClosedPosition, ExecutionAction, IgnoredDecisionReason, RiskExitKind, RiskExitTriggered,
-    RuntimePortfolioSnapshot, SecondaryReadiness, StrategyDecision,
+    RuntimePortfolioSnapshot, SecondaryReadiness, StrategyDecision, StrategyError,
 };
 use shared::{Candle, Position, Timeframe};
 
@@ -61,6 +61,10 @@ pub enum RuntimeEvent {
     },
     StrategyDecisionProduced {
         decision: StrategyDecision,
+    },
+    StrategyError {
+        candle: Candle,
+        error: StrategyError,
     },
     ExecutionActionPlanned {
         action: ExecutionAction,

--- a/trading-runtime/src/lib.rs
+++ b/trading-runtime/src/lib.rs
@@ -41,4 +41,7 @@ pub use risk_exit::{evaluate_risk_exit, RiskExitKind, RiskExitTriggered};
 pub use runtime::TradingRuntime;
 pub use shared::{Timeframe, TimeframeParseError, TimeframeUnit};
 pub use step::RuntimeStep;
-pub use strategy::{PredeterminedStrategyHandler, StrategyHandler};
+pub use strategy::{
+    MarketView, PredeterminedStrategyHandler, StrategyContext, StrategyError, StrategyHandler,
+    StrategyState, StrategyTickInput, StrategyTickResult,
+};

--- a/trading-runtime/src/lib.rs
+++ b/trading-runtime/src/lib.rs
@@ -26,6 +26,7 @@ pub mod runtime;
 pub mod step;
 pub mod strategy;
 pub mod strategy_config;
+pub mod warmup;
 
 pub use decision::{
     validate_opening_quantity, InvalidOpeningQuantity, StrategyDecision, StrategyDecisionIntent,
@@ -54,3 +55,4 @@ pub use strategy::{
     StrategyState, StrategyStateValue, StrategyTickInput, StrategyTickResult,
 };
 pub use strategy_config::StrategyConfiguration;
+pub use warmup::{detect_auto_warmup, resolve_effective_warmup, resolve_warmup_plan, WarmupPlan};

--- a/trading-runtime/src/lib.rs
+++ b/trading-runtime/src/lib.rs
@@ -14,6 +14,7 @@
 //! The old `engine` crate remains only donor material for strategy-handling
 //! behavior; this crate must stay independent from it.
 
+pub mod anchored;
 pub mod decision;
 pub mod events;
 pub mod execution;
@@ -28,6 +29,11 @@ pub mod strategy;
 pub mod strategy_config;
 pub mod warmup;
 
+pub use anchored::{
+    AnchoredConfiguration, AnchoredConfigurationError, AnchoredDetectorSpec,
+    AnchoredEvaluatorConfiguration, AnchoredEvaluatorSpec, AnchoredOutput, AnchoredOutputs,
+    AnchoredRuntime, PivotDetectorConfiguration, PivotEvent, PivotSide,
+};
 pub use decision::{
     validate_opening_quantity, InvalidOpeningQuantity, StrategyDecision, StrategyDecisionIntent,
 };
@@ -43,9 +49,7 @@ pub use market_state::MarketState;
 pub use portfolio::{
     ClosedPosition, PortfolioState, PortfolioTransitionError, RuntimePortfolioSnapshot,
 };
-pub use rhai_strategy::{
-    AnchoredConfiguration, RhaiStrategy, RhaiStrategyHooks, RhaiStrategyLoadError,
-};
+pub use rhai_strategy::{RhaiStrategy, RhaiStrategyHooks, RhaiStrategyLoadError};
 pub use risk_exit::{evaluate_risk_exit, RiskExitKind, RiskExitTriggered};
 pub use runtime::TradingRuntime;
 pub use shared::{Timeframe, TimeframeParseError, TimeframeUnit};

--- a/trading-runtime/src/lib.rs
+++ b/trading-runtime/src/lib.rs
@@ -4,12 +4,13 @@
 //! strategy-decision planning, runtime-local portfolio state, realized-cash
 //! portfolio transitions, explicit force-close commands, warmup progression,
 //! ordered runner-neutral runtime events, Rhai strategy loading/hook validation,
-//! typed Rhai decisions, grouped Rhai Strategy Context/Strategy State, and
+//! typed Rhai decisions, grouped Rhai Strategy Context/Strategy State, typed
+//! Rhai Market View access for configured Primary/Secondary timeframes, and
 //! [`RuntimeStep`] return values.
 //!
 //! This slice intentionally does not include database persistence, live-daemon or
 //! backtester wiring, real broker execution, dynamic risk updates, or the full
-//! typed Market View Rhai API.
+//! live/backtester migration.
 //! The old `engine` crate remains only donor material for strategy-handling
 //! behavior; this crate must stay independent from it.
 

--- a/trading-runtime/src/lib.rs
+++ b/trading-runtime/src/lib.rs
@@ -3,13 +3,14 @@
 //! This crate is the first runtime-core slice for one runtime asset. It owns
 //! strategy-decision planning, runtime-local portfolio state, realized-cash
 //! portfolio transitions, explicit force-close commands, warmup progression,
-//! ordered runner-neutral runtime events, and [`RuntimeStep`] return values.
+//! ordered runner-neutral runtime events, Rhai strategy loading/hook validation,
+//! and [`RuntimeStep`] return values.
 //!
-//! This slice intentionally does not include Rhai strategy execution, database
-//! persistence, live-daemon or backtester wiring, real broker execution,
-//! secondary timeframe market views, dynamic risk updates, or stop-loss /
-//! take-profit trigger rules. The old `engine` crate remains only a future donor
-//! for strategy-handling behavior; this crate must stay independent from it.
+//! This slice intentionally does not include Rhai strategy tick execution,
+//! database persistence, live-daemon or backtester wiring, real broker execution,
+//! dynamic risk updates, or full typed Market View / Strategy Context Rhai APIs.
+//! The old `engine` crate remains only donor material for strategy-handling
+//! behavior; this crate must stay independent from it.
 
 pub mod decision;
 pub mod events;
@@ -17,6 +18,7 @@ pub mod execution;
 pub mod market_input;
 pub mod market_state;
 pub mod portfolio;
+pub mod rhai_strategy;
 pub mod risk_exit;
 pub mod runtime;
 pub mod step;
@@ -36,6 +38,10 @@ pub use market_input::{
 pub use market_state::MarketState;
 pub use portfolio::{
     ClosedPosition, PortfolioState, PortfolioTransitionError, RuntimePortfolioSnapshot,
+};
+pub use rhai_strategy::{
+    AnchoredConfiguration, RhaiStrategy, RhaiStrategyHooks, RhaiStrategyLoadError,
+    StrategyConfiguration,
 };
 pub use risk_exit::{evaluate_risk_exit, RiskExitKind, RiskExitTriggered};
 pub use runtime::TradingRuntime;

--- a/trading-runtime/src/lib.rs
+++ b/trading-runtime/src/lib.rs
@@ -24,6 +24,7 @@ pub mod risk_exit;
 pub mod runtime;
 pub mod step;
 pub mod strategy;
+pub mod strategy_config;
 
 pub use decision::{
     validate_opening_quantity, InvalidOpeningQuantity, StrategyDecision, StrategyDecisionIntent,
@@ -42,7 +43,6 @@ pub use portfolio::{
 };
 pub use rhai_strategy::{
     AnchoredConfiguration, RhaiStrategy, RhaiStrategyHooks, RhaiStrategyLoadError,
-    StrategyConfiguration,
 };
 pub use risk_exit::{evaluate_risk_exit, RiskExitKind, RiskExitTriggered};
 pub use runtime::TradingRuntime;
@@ -52,3 +52,4 @@ pub use strategy::{
     MarketView, PredeterminedStrategyHandler, StrategyContext, StrategyError, StrategyHandler,
     StrategyState, StrategyStateValue, StrategyTickInput, StrategyTickResult,
 };
+pub use strategy_config::StrategyConfiguration;

--- a/trading-runtime/src/lib.rs
+++ b/trading-runtime/src/lib.rs
@@ -4,11 +4,12 @@
 //! strategy-decision planning, runtime-local portfolio state, realized-cash
 //! portfolio transitions, explicit force-close commands, warmup progression,
 //! ordered runner-neutral runtime events, Rhai strategy loading/hook validation,
-//! and [`RuntimeStep`] return values.
+//! typed Rhai decisions, grouped Rhai Strategy Context/Strategy State, and
+//! [`RuntimeStep`] return values.
 //!
-//! This slice intentionally does not include Rhai strategy tick execution,
-//! database persistence, live-daemon or backtester wiring, real broker execution,
-//! dynamic risk updates, or full typed Market View / Strategy Context Rhai APIs.
+//! This slice intentionally does not include database persistence, live-daemon or
+//! backtester wiring, real broker execution, dynamic risk updates, or the full
+//! typed Market View Rhai API.
 //! The old `engine` crate remains only donor material for strategy-handling
 //! behavior; this crate must stay independent from it.
 
@@ -49,5 +50,5 @@ pub use shared::{Timeframe, TimeframeParseError, TimeframeUnit};
 pub use step::RuntimeStep;
 pub use strategy::{
     MarketView, PredeterminedStrategyHandler, StrategyContext, StrategyError, StrategyHandler,
-    StrategyState, StrategyTickInput, StrategyTickResult,
+    StrategyState, StrategyStateValue, StrategyTickInput, StrategyTickResult,
 };

--- a/trading-runtime/src/market_input.rs
+++ b/trading-runtime/src/market_input.rs
@@ -1,5 +1,6 @@
 //! Runtime market-input boundary types.
 
+use crate::strategy_config::StrategyConfiguration;
 use shared::{Candle, Timeframe};
 
 /// Whether a configured Secondary Timeframe is required for Strategy Ticks.
@@ -101,6 +102,35 @@ impl RuntimeConfig {
 
     pub(crate) fn secondary_configs(&self) -> &[SecondaryTimeframeConfig] {
         &self.secondary_timeframes
+    }
+
+    /// Resolve strategy-declared configuration into this run configuration.
+    ///
+    /// Run Configuration remains authoritative: existing Secondary-Timeframe
+    /// entries keep their readiness/tolerance, and the runtime asset and Primary
+    /// Timeframe are never changed by Strategy Configuration. Strategy-declared
+    /// Secondary Timeframes that are absent from the run config are added.
+    pub fn merge_strategy_config(&self, strategy_config: &StrategyConfiguration) -> Self {
+        let mut resolved = self.clone();
+
+        for strategy_secondary in strategy_config.secondary_timeframes() {
+            if strategy_secondary.timeframe == resolved.primary_timeframe {
+                continue;
+            }
+
+            let run_config_has_timeframe = resolved
+                .secondary_timeframes
+                .iter()
+                .any(|run_secondary| run_secondary.timeframe == strategy_secondary.timeframe);
+
+            if !run_config_has_timeframe {
+                resolved
+                    .secondary_timeframes
+                    .push(strategy_secondary.clone());
+            }
+        }
+
+        resolved
     }
 }
 

--- a/trading-runtime/src/rhai_strategy.rs
+++ b/trading-runtime/src/rhai_strategy.rs
@@ -1,16 +1,17 @@
 //! Rhai strategy loading and hook validation for the trading runtime.
 //!
 //! This module owns compile/load-time Rhai strategy handling inside the
-//! `trading-runtime` crate, the typed decision API, and grouped Strategy Context
-//! / Strategy State used at the strategy tick boundary. Full strategy-facing
-//! Market View APIs are implemented in later Strategy Handling slices.
+//! `trading-runtime` crate, the typed decision API, grouped Strategy Context /
+//! Strategy State, and the Primary-Timeframe Market View used at the strategy
+//! tick boundary. Secondary Market View access is implemented in a later slice.
 
 use crate::{
     RuntimePortfolioSnapshot, StrategyDecision, StrategyError, StrategyHandler, StrategyState,
     StrategyStateValue, StrategyTickInput, StrategyTickResult,
 };
+use indicators::trend::sma::sma;
 use rhai::{Dynamic, Engine as RhaiEngine, EvalAltResult, Module, Scope, AST, FLOAT, INT};
-use shared::{Position, Timeframe};
+use shared::{Candle, Position, Timeframe};
 use std::{error::Error, fmt, path::Path, sync::Arc};
 
 /// Typed strategy-declared configuration returned by `strategy_config()`.
@@ -63,6 +64,57 @@ pub struct RhaiStrategy {
 }
 
 #[derive(Debug, Clone)]
+struct RhaiMarketView {
+    current: RhaiCandle,
+    primary_history: RhaiCandleHistory,
+}
+
+impl RhaiMarketView {
+    fn from_runtime(market: &crate::MarketView<'_>) -> Self {
+        Self {
+            current: RhaiCandle::new(market.primary_candle().clone()),
+            primary_history: RhaiCandleHistory::new(market.primary_history().to_vec()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct RhaiCandle {
+    candle: Candle,
+}
+
+impl RhaiCandle {
+    fn new(candle: Candle) -> Self {
+        Self { candle }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RhaiCandleHistory {
+    candles: Arc<Vec<Candle>>,
+}
+
+impl RhaiCandleHistory {
+    fn new(candles: Vec<Candle>) -> Self {
+        Self {
+            candles: Arc::new(candles),
+        }
+    }
+
+    fn chronological_candles_before_offset(&self, offset: usize) -> &[Candle] {
+        let end = self.candles.len().saturating_sub(offset);
+        &self.candles[..end]
+    }
+
+    fn chronological_closes_before_offset(&self, offset: usize) -> Vec<f64> {
+        self.chronological_candles_before_offset(offset)
+            .iter()
+            .map(|candle| candle.close)
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone)]
 struct RhaiStrategyContext {
     portfolio: RhaiPortfolioSnapshot,
     state: StrategyState,
@@ -109,6 +161,7 @@ impl RhaiPosition {
 
 impl StrategyHandler for RhaiStrategy {
     fn on_tick(&mut self, input: StrategyTickInput<'_>) -> StrategyTickResult {
+        let market = RhaiMarketView::from_runtime(&input.market);
         let context =
             RhaiStrategyContext::from_runtime(input.context.portfolio, input.context.state);
 
@@ -116,7 +169,7 @@ impl StrategyHandler for RhaiStrategy {
             &mut self.scope,
             &self.ast,
             ON_TICK_HOOK,
-            ((), context),
+            (market, context),
         ) {
             Ok(result) => result,
             Err(error) => {
@@ -302,14 +355,20 @@ fn new_rhai_engine() -> RhaiEngine {
     engine.register_type_with_name::<StrategyConfiguration>("StrategyConfig");
     engine.register_type_with_name::<AnchoredConfiguration>("AnchoredConfig");
     engine.register_type_with_name::<StrategyDecision>("StrategyDecision");
+    engine.register_type_with_name::<RhaiMarketView>("MarketView");
+    engine.register_type_with_name::<RhaiCandle>("Candle");
+    engine.register_type_with_name::<RhaiCandleHistory>("CandleHistory");
     engine.register_type_with_name::<RhaiStrategyContext>("StrategyContext");
     engine.register_type_with_name::<RhaiPortfolioSnapshot>("PortfolioSnapshot");
     engine.register_type_with_name::<RhaiPosition>("Position");
     engine.register_type_with_name::<StrategyState>("StrategyState");
 
+    register_market_view_api(&mut engine);
     register_strategy_context_api(&mut engine);
+    register_indicator_api(&mut engine);
 
     engine.register_fn("timeframe", parse_timeframe);
+    engine.register_fn("==", |left: Timeframe, right: Timeframe| left == right);
     engine.register_fn(
         "with_minimum_warmup",
         |config: StrategyConfiguration, minimum_warmup: INT| {
@@ -518,6 +577,81 @@ fn register_strategy_context_api(engine: &mut RhaiEngine) {
 fn parse_timeframe(raw: &str) -> Result<Timeframe, Box<EvalAltResult>> {
     raw.parse::<Timeframe>()
         .map_err(|error| format!("invalid timeframe `{raw}`: {error}").into())
+}
+
+fn register_market_view_api(engine: &mut RhaiEngine) {
+    engine.register_fn("candle", |market: &mut RhaiMarketView| {
+        market.current.clone()
+    });
+    engine.register_fn("candles", |market: &mut RhaiMarketView| {
+        market.primary_history.clone()
+    });
+
+    engine.register_get("open", |candle: &mut RhaiCandle| candle.candle.open);
+    engine.register_get("high", |candle: &mut RhaiCandle| candle.candle.high);
+    engine.register_get("low", |candle: &mut RhaiCandle| candle.candle.low);
+    engine.register_get("close", |candle: &mut RhaiCandle| candle.candle.close);
+    engine.register_get("volume", |candle: &mut RhaiCandle| candle.candle.volume);
+    engine.register_get("timestamp", |candle: &mut RhaiCandle| {
+        candle.candle.timestamp as INT
+    });
+    engine.register_get("symbol", |candle: &mut RhaiCandle| {
+        candle.candle.symbol.clone()
+    });
+    engine.register_get("timeframe", |candle: &mut RhaiCandle| {
+        candle.candle.timeframe
+    });
+    engine.register_fn("body", |candle: &mut RhaiCandle| candle.candle.body());
+    engine.register_fn("range", |candle: &mut RhaiCandle| candle.candle.range());
+
+    engine.register_indexer_get(|history: &mut RhaiCandleHistory, index: INT| -> Dynamic {
+        if index < 1 {
+            return Dynamic::UNIT;
+        }
+
+        let len = history.candles.len();
+        match len.checked_sub(index as usize) {
+            Some(position) => Dynamic::from(RhaiCandle::new(history.candles[position].clone())),
+            None => Dynamic::UNIT,
+        }
+    });
+    engine.register_fn("len", |history: &mut RhaiCandleHistory| -> INT {
+        history.candles.len() as INT
+    });
+}
+
+fn register_indicator_api(engine: &mut RhaiEngine) {
+    let mut indicators_module = Module::new();
+    indicators_module.set_native_fn(
+        "sma",
+        |history: &mut RhaiCandleHistory, period: INT| -> Result<Dynamic, Box<EvalAltResult>> {
+            Ok(option_f64(sma(
+                &history.chronological_closes_before_offset(0),
+                non_negative_usize(period)?,
+            )))
+        },
+    );
+    indicators_module.set_native_fn(
+        "sma",
+        |history: &mut RhaiCandleHistory,
+         period: INT,
+         offset: INT|
+         -> Result<Dynamic, Box<EvalAltResult>> {
+            Ok(option_f64(sma(
+                &history.chronological_closes_before_offset(non_negative_usize(offset)?),
+                non_negative_usize(period)?,
+            )))
+        },
+    );
+    engine.register_static_module("indicators", Arc::new(indicators_module));
+}
+
+fn option_f64(value: Option<f64>) -> Dynamic {
+    value.map(Dynamic::from).unwrap_or(Dynamic::UNIT)
+}
+
+fn non_negative_usize(value: INT) -> Result<usize, Box<EvalAltResult>> {
+    usize::try_from(value).map_err(|_| "value must be a non-negative integer".into())
 }
 
 fn strategy_state_get_int(
@@ -939,6 +1073,129 @@ if seen == 0 {
         assert_eq!(
             produced_decision(&first_strategy_tick),
             StrategyDecision::hold()
+        );
+    }
+
+    #[test]
+    fn market_view_exposes_current_primary_candle_fields() {
+        let source = source_returning(
+            r#"
+let c = market.candle();
+if c.open == 100.0
+        && c.high == 100.0
+        && c.low == 100.0
+        && c.close == 100.0
+        && c.volume == 1000.0
+        && c.timestamp == 1
+        && c.symbol == "BTC-USD"
+        && c.timeframe == timeframe("1m") {
+    decision::open_long(1.0)
+} else {
+    decision::hold()
+}
+"#,
+        );
+
+        let step = run_completed_tick(&source);
+
+        assert_eq!(produced_decision(&step), StrategyDecision::open_long(1.0));
+    }
+
+    #[test]
+    fn market_view_primary_history_is_newest_first_one_indexed_and_unit_out_of_range() {
+        let source = source_returning(
+            r#"
+let history = market.candles();
+let current = market.candle();
+
+if history[0] == () || history[3] == () {
+    if history[1] != ()
+            && history[2] != ()
+            && history[1].close == current.close
+            && history[1].close == 101.0
+            && history[2].close == 100.0 {
+        decision::open_long(1.0)
+    } else {
+        decision::hold()
+    }
+} else {
+    decision::open_short(1.0)
+}
+"#,
+        );
+        let strategy = RhaiStrategy::load(&source).expect("strategy should load");
+        let mut runtime = TradingRuntime::new(PortfolioState::new(1_000.0), 0, strategy);
+
+        let first = runtime
+            .on_market_input(MarketInput::CompletedCandle(candle(100.0)))
+            .expect("first completed primary candle should be accepted");
+        let second = runtime
+            .on_market_input(MarketInput::CompletedCandle(candle(101.0)))
+            .expect("second completed primary candle should be accepted");
+
+        assert_eq!(produced_decision(&first), StrategyDecision::hold());
+        assert_eq!(produced_decision(&second), StrategyDecision::open_long(1.0));
+    }
+
+    #[test]
+    fn market_view_history_accepts_sma_indicator_binding() {
+        let source = source_returning(
+            r#"
+let average = indicators::sma(market.candles(), 3);
+if average != () && average == 101.0 {
+    decision::open_long(1.0)
+} else {
+    decision::hold()
+}
+"#,
+        );
+        let strategy = RhaiStrategy::load(&source).expect("strategy should load");
+        let mut runtime = TradingRuntime::new(PortfolioState::new(1_000.0), 0, strategy);
+
+        let first = runtime
+            .on_market_input(MarketInput::CompletedCandle(candle(100.0)))
+            .expect("first completed primary candle should be accepted");
+        let second = runtime
+            .on_market_input(MarketInput::CompletedCandle(candle(101.0)))
+            .expect("second completed primary candle should be accepted");
+        let third = runtime
+            .on_market_input(MarketInput::CompletedCandle(candle(102.0)))
+            .expect("third completed primary candle should be accepted");
+
+        assert_eq!(produced_decision(&first), StrategyDecision::hold());
+        assert_eq!(produced_decision(&second), StrategyDecision::hold());
+        assert_eq!(produced_decision(&third), StrategyDecision::open_long(1.0));
+    }
+
+    #[test]
+    fn warmup_input_populates_market_state_without_calling_rhai_on_tick() {
+        let source = source_returning(
+            r#"
+let previous = market.candles()[2];
+if previous != () && previous.close == 99.0 {
+    decision::open_long(1.0)
+} else {
+    decision::hold()
+}
+"#,
+        );
+        let strategy = RhaiStrategy::load(&source).expect("strategy should load");
+        let mut runtime = TradingRuntime::new(PortfolioState::new(1_000.0), 1, strategy);
+
+        let warmup = runtime
+            .on_market_input(MarketInput::WarmupCandle(candle(99.0)))
+            .expect("warmup candle should be accepted");
+        let first_strategy_tick = runtime
+            .on_market_input(MarketInput::CompletedCandle(candle(100.0)))
+            .expect("completed primary candle should be accepted");
+
+        assert!(!warmup
+            .events
+            .iter()
+            .any(|event| matches!(event, RuntimeEvent::StrategyTickStarted { .. })));
+        assert_eq!(
+            produced_decision(&first_strategy_tick),
+            StrategyDecision::open_long(1.0)
         );
     }
 

--- a/trading-runtime/src/rhai_strategy.rs
+++ b/trading-runtime/src/rhai_strategy.rs
@@ -1,15 +1,16 @@
 //! Rhai strategy loading and hook validation for the trading runtime.
 //!
 //! This module owns compile/load-time Rhai strategy handling inside the
-//! `trading-runtime` crate and the typed decision API used at the strategy tick
-//! boundary. Full strategy-facing Market View and Context APIs are implemented
-//! in later Strategy Handling slices.
+//! `trading-runtime` crate, the typed decision API, and grouped Strategy Context
+//! / Strategy State used at the strategy tick boundary. Full strategy-facing
+//! Market View APIs are implemented in later Strategy Handling slices.
 
 use crate::{
-    StrategyDecision, StrategyError, StrategyHandler, StrategyTickInput, StrategyTickResult,
+    RuntimePortfolioSnapshot, StrategyDecision, StrategyError, StrategyHandler, StrategyState,
+    StrategyStateValue, StrategyTickInput, StrategyTickResult,
 };
 use rhai::{Dynamic, Engine as RhaiEngine, EvalAltResult, Module, Scope, AST, FLOAT, INT};
-use shared::Timeframe;
+use shared::{Position, Timeframe};
 use std::{error::Error, fmt, path::Path, sync::Arc};
 
 /// Typed strategy-declared configuration returned by `strategy_config()`.
@@ -61,20 +62,69 @@ pub struct RhaiStrategy {
     anchored_config: Option<AnchoredConfiguration>,
 }
 
+#[derive(Debug, Clone)]
+struct RhaiStrategyContext {
+    portfolio: RhaiPortfolioSnapshot,
+    state: StrategyState,
+}
+
+impl RhaiStrategyContext {
+    fn from_runtime(portfolio: &RuntimePortfolioSnapshot, state: &StrategyState) -> Self {
+        Self {
+            portfolio: RhaiPortfolioSnapshot::from_runtime(portfolio),
+            state: state.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RhaiPortfolioSnapshot {
+    realized_cash_balance: f64,
+    equity: f64,
+    completed_trades: INT,
+    position: Option<RhaiPosition>,
+}
+
+impl RhaiPortfolioSnapshot {
+    fn from_runtime(snapshot: &RuntimePortfolioSnapshot) -> Self {
+        Self {
+            realized_cash_balance: snapshot.realized_cash_balance,
+            equity: snapshot.current_equity,
+            completed_trades: snapshot.completed_trade_count as INT,
+            position: snapshot.open_position.clone().map(RhaiPosition::new),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RhaiPosition {
+    position: Position,
+}
+
+impl RhaiPosition {
+    fn new(position: Position) -> Self {
+        Self { position }
+    }
+}
+
 impl StrategyHandler for RhaiStrategy {
-    fn on_tick(&mut self, _input: StrategyTickInput<'_>) -> StrategyTickResult {
-        let result =
-            match self
-                .engine
-                .call_fn::<Dynamic>(&mut self.scope, &self.ast, ON_TICK_HOOK, ((), ()))
-            {
-                Ok(result) => result,
-                Err(error) => {
-                    return StrategyTickResult::Error(StrategyError::new(format!(
-                        "strategy hook `on_tick` failed: {error}"
-                    )))
-                }
-            };
+    fn on_tick(&mut self, input: StrategyTickInput<'_>) -> StrategyTickResult {
+        let context =
+            RhaiStrategyContext::from_runtime(input.context.portfolio, input.context.state);
+
+        let result = match self.engine.call_fn::<Dynamic>(
+            &mut self.scope,
+            &self.ast,
+            ON_TICK_HOOK,
+            ((), context),
+        ) {
+            Ok(result) => result,
+            Err(error) => {
+                return StrategyTickResult::Error(StrategyError::new(format!(
+                    "strategy hook `on_tick` failed: {error}"
+                )))
+            }
+        };
 
         let actual_type = result.type_name().to_string();
         match result.try_cast::<StrategyDecision>() {
@@ -252,6 +302,12 @@ fn new_rhai_engine() -> RhaiEngine {
     engine.register_type_with_name::<StrategyConfiguration>("StrategyConfig");
     engine.register_type_with_name::<AnchoredConfiguration>("AnchoredConfig");
     engine.register_type_with_name::<StrategyDecision>("StrategyDecision");
+    engine.register_type_with_name::<RhaiStrategyContext>("StrategyContext");
+    engine.register_type_with_name::<RhaiPortfolioSnapshot>("PortfolioSnapshot");
+    engine.register_type_with_name::<RhaiPosition>("Position");
+    engine.register_type_with_name::<StrategyState>("StrategyState");
+
+    register_strategy_context_api(&mut engine);
 
     engine.register_fn("timeframe", parse_timeframe);
     engine.register_fn(
@@ -394,9 +450,152 @@ fn copy_until_string_end(source: &str, start: usize, output: &mut String) -> usi
     end
 }
 
+fn register_strategy_context_api(engine: &mut RhaiEngine) {
+    engine.register_get("portfolio", |context: &mut RhaiStrategyContext| {
+        context.portfolio.clone()
+    });
+    engine.register_get("state", |context: &mut RhaiStrategyContext| {
+        context.state.clone()
+    });
+
+    engine.register_get(
+        "realized_cash_balance",
+        |portfolio: &mut RhaiPortfolioSnapshot| portfolio.realized_cash_balance,
+    );
+    engine.register_get("equity", |portfolio: &mut RhaiPortfolioSnapshot| {
+        portfolio.equity
+    });
+    engine.register_get(
+        "completed_trades",
+        |portfolio: &mut RhaiPortfolioSnapshot| portfolio.completed_trades,
+    );
+    engine.register_get(
+        "position",
+        |portfolio: &mut RhaiPortfolioSnapshot| -> Dynamic {
+            portfolio
+                .position
+                .clone()
+                .map(Dynamic::from)
+                .unwrap_or(Dynamic::UNIT)
+        },
+    );
+
+    engine.register_get("side", |position: &mut RhaiPosition| {
+        position.position.side.to_string()
+    });
+    engine.register_get("entry_price", |position: &mut RhaiPosition| {
+        position.position.entry_price
+    });
+    engine.register_get("size", |position: &mut RhaiPosition| position.position.size);
+    engine.register_get("entry_time", |position: &mut RhaiPosition| {
+        position.position.entry_time
+    });
+    engine.register_get("stop_loss", |position: &mut RhaiPosition| -> Dynamic {
+        position
+            .position
+            .stop_loss
+            .map(Dynamic::from)
+            .unwrap_or(Dynamic::UNIT)
+    });
+    engine.register_get("take_profit", |position: &mut RhaiPosition| -> Dynamic {
+        position
+            .position
+            .take_profit
+            .map(Dynamic::from)
+            .unwrap_or(Dynamic::UNIT)
+    });
+
+    engine.register_fn("get", strategy_state_get_int);
+    engine.register_fn("get", strategy_state_get_float);
+    engine.register_fn("get", strategy_state_get_bool);
+    engine.register_fn("get", strategy_state_get_string);
+    engine.register_fn("set", strategy_state_set_int);
+    engine.register_fn("set", strategy_state_set_float);
+    engine.register_fn("set", strategy_state_set_bool);
+    engine.register_fn("set", strategy_state_set_string);
+}
+
 fn parse_timeframe(raw: &str) -> Result<Timeframe, Box<EvalAltResult>> {
     raw.parse::<Timeframe>()
         .map_err(|error| format!("invalid timeframe `{raw}`: {error}").into())
+}
+
+fn strategy_state_get_int(
+    state: StrategyState,
+    key: &str,
+    default: INT,
+) -> Result<INT, Box<EvalAltResult>> {
+    match state.get(key) {
+        Some(StrategyStateValue::Int(value)) => Ok(value),
+        Some(value) => Err(strategy_state_type_error(key, "int", value)),
+        None => Ok(default),
+    }
+}
+
+fn strategy_state_get_float(
+    state: StrategyState,
+    key: &str,
+    default: FLOAT,
+) -> Result<FLOAT, Box<EvalAltResult>> {
+    match state.get(key) {
+        Some(StrategyStateValue::Float(value)) => Ok(value),
+        Some(value) => Err(strategy_state_type_error(key, "float", value)),
+        None => Ok(default),
+    }
+}
+
+fn strategy_state_get_bool(
+    state: StrategyState,
+    key: &str,
+    default: bool,
+) -> Result<bool, Box<EvalAltResult>> {
+    match state.get(key) {
+        Some(StrategyStateValue::Bool(value)) => Ok(value),
+        Some(value) => Err(strategy_state_type_error(key, "bool", value)),
+        None => Ok(default),
+    }
+}
+
+fn strategy_state_get_string(
+    state: StrategyState,
+    key: &str,
+    default: &str,
+) -> Result<String, Box<EvalAltResult>> {
+    match state.get(key) {
+        Some(StrategyStateValue::String(value)) => Ok(value),
+        Some(value) => Err(strategy_state_type_error(key, "string", value)),
+        None => Ok(default.to_string()),
+    }
+}
+
+fn strategy_state_set_int(state: StrategyState, key: &str, value: INT) {
+    state.set(key, StrategyStateValue::Int(value));
+}
+
+fn strategy_state_set_float(state: StrategyState, key: &str, value: FLOAT) {
+    state.set(key, StrategyStateValue::Float(value));
+}
+
+fn strategy_state_set_bool(state: StrategyState, key: &str, value: bool) {
+    state.set(key, StrategyStateValue::Bool(value));
+}
+
+fn strategy_state_set_string(state: StrategyState, key: &str, value: &str) {
+    state.set(key, StrategyStateValue::String(value.to_string()));
+}
+
+fn strategy_state_type_error(
+    key: &str,
+    expected: &'static str,
+    actual: StrategyStateValue,
+) -> Box<EvalAltResult> {
+    let actual = match actual {
+        StrategyStateValue::Int(_) => "int",
+        StrategyStateValue::Float(_) => "float",
+        StrategyStateValue::Bool(_) => "bool",
+        StrategyStateValue::String(_) => "string",
+    };
+    format!("strategy state key `{key}` contains {actual}, not requested {expected}").into()
 }
 
 fn with_minimum_warmup(
@@ -593,6 +792,233 @@ fn on_tick(market, context) {{
                 _ => None,
             })
             .expect("step should include a produced strategy decision")
+    }
+
+    fn strategy_error_message(step: &crate::RuntimeStep) -> String {
+        step.events
+            .iter()
+            .find_map(|event| match event {
+                RuntimeEvent::StrategyError { error, .. } => Some(error.message.clone()),
+                _ => None,
+            })
+            .expect("step should include a strategy error")
+    }
+
+    #[test]
+    fn grouped_context_exposes_flat_portfolio_snapshot_without_flat_context_aliases() {
+        let source = source_returning(
+            r#"
+if context.portfolio.equity == 1000.0
+        && context.portfolio.realized_cash_balance == 1000.0
+        && context.portfolio.completed_trades == 0
+        && context.portfolio.position == () {
+    decision::open_long(1.0)
+} else {
+    decision::hold()
+}
+"#,
+        );
+
+        let step = run_completed_tick(&source);
+
+        assert_eq!(produced_decision(&step), StrategyDecision::open_long(1.0));
+    }
+
+    #[test]
+    fn grouped_context_exposes_open_position_details() {
+        let source = source_returning(
+            r#"
+let position = context.portfolio.position;
+if position != ()
+        && position.side == "long"
+        && position.entry_price == 100.0
+        && position.size == 2.0
+        && position.entry_time == 1
+        && position.stop_loss == 90.0
+        && position.take_profit == 120.0 {
+    decision::close_long()
+} else {
+    decision::hold()
+}
+"#,
+        );
+        let strategy = RhaiStrategy::load(&source).expect("strategy should load");
+        let mut portfolio = PortfolioState::new(1_000.0);
+        portfolio
+            .open_long_from_flat(&candle(100.0), 2.0, Some(90.0), Some(120.0))
+            .expect("position should open");
+        let mut runtime = TradingRuntime::new(portfolio, 0, strategy);
+
+        let step = runtime
+            .on_market_input(MarketInput::CompletedCandle(candle(105.0)))
+            .expect("completed primary candle should be accepted");
+
+        assert_eq!(produced_decision(&step), StrategyDecision::close_long());
+    }
+
+    #[test]
+    fn strategy_state_get_set_persists_primitives_between_strategy_ticks() {
+        let source = source_returning(
+            r#"
+let seen = context.state.get("seen", 0);
+context.state.set("seen", seen + 1);
+
+if seen == 0 {
+    decision::hold()
+} else {
+    decision::open_long(1.0)
+}
+"#,
+        );
+        let strategy = RhaiStrategy::load(&source).expect("strategy should load");
+        let mut runtime = TradingRuntime::new(PortfolioState::new(1_000.0), 0, strategy);
+
+        let first = runtime
+            .on_market_input(MarketInput::CompletedCandle(candle(100.0)))
+            .expect("first completed primary candle should be accepted");
+        let second = runtime
+            .on_market_input(MarketInput::CompletedCandle(candle(101.0)))
+            .expect("second completed primary candle should be accepted");
+
+        assert_eq!(produced_decision(&first), StrategyDecision::hold());
+        assert_eq!(produced_decision(&second), StrategyDecision::open_long(1.0));
+    }
+
+    #[test]
+    fn strategy_state_starts_empty_for_each_runtime_session() {
+        let source = source_returning(
+            r#"
+let seen = context.state.get("seen", 0);
+context.state.set("seen", seen + 1);
+
+if seen == 0 {
+    decision::hold()
+} else {
+    decision::open_long(1.0)
+}
+"#,
+        );
+
+        let first_step_in_first_runtime = run_completed_tick(&source);
+        let first_step_in_second_runtime = run_completed_tick(&source);
+
+        assert_eq!(
+            produced_decision(&first_step_in_first_runtime),
+            StrategyDecision::hold()
+        );
+        assert_eq!(
+            produced_decision(&first_step_in_second_runtime),
+            StrategyDecision::hold()
+        );
+    }
+
+    #[test]
+    fn warmup_input_does_not_mutate_strategy_state() {
+        let source = source_returning(
+            r#"
+let seen = context.state.get("seen", 0);
+context.state.set("seen", seen + 1);
+
+if seen == 0 {
+    decision::hold()
+} else {
+    decision::open_long(1.0)
+}
+"#,
+        );
+        let strategy = RhaiStrategy::load(&source).expect("strategy should load");
+        let mut runtime = TradingRuntime::new(PortfolioState::new(1_000.0), 1, strategy);
+
+        runtime
+            .on_market_input(MarketInput::WarmupCandle(candle(99.0)))
+            .expect("warmup candle should be accepted");
+        let first_strategy_tick = runtime
+            .on_market_input(MarketInput::CompletedCandle(candle(100.0)))
+            .expect("completed primary candle should be accepted");
+
+        assert_eq!(
+            produced_decision(&first_strategy_tick),
+            StrategyDecision::hold()
+        );
+    }
+
+    #[test]
+    fn strategy_state_supports_float_bool_and_string_values() {
+        let source = source_returning(
+            r#"
+let price = context.state.get("price", 1.5);
+let enabled = context.state.get("enabled", false);
+let label = context.state.get("label", "cold");
+
+context.state.set("price", price + 1.0);
+context.state.set("enabled", true);
+context.state.set("label", "warm");
+
+if price == 2.5 && enabled && label == "warm" {
+    decision::open_long(1.0)
+} else {
+    decision::hold()
+}
+"#,
+        );
+        let strategy = RhaiStrategy::load(&source).expect("strategy should load");
+        let mut runtime = TradingRuntime::new(PortfolioState::new(1_000.0), 0, strategy);
+
+        let first = runtime
+            .on_market_input(MarketInput::CompletedCandle(candle(100.0)))
+            .expect("first completed primary candle should be accepted");
+        let second = runtime
+            .on_market_input(MarketInput::CompletedCandle(candle(101.0)))
+            .expect("second completed primary candle should be accepted");
+
+        assert_eq!(produced_decision(&first), StrategyDecision::hold());
+        assert_eq!(produced_decision(&second), StrategyDecision::open_long(1.0));
+    }
+
+    #[test]
+    fn unsupported_strategy_state_values_fail_at_tick_time() {
+        for expression in [
+            r#"context.state.set("items", [1, 2, 3]);"#,
+            r#"context.state.set("shape", #{ seen: 1 });"#,
+        ] {
+            let source = source_returning(&format!(
+                r#"
+{expression}
+decision::hold()
+"#
+            ));
+            let step = run_completed_tick(&source);
+            let message = strategy_error_message(&step);
+
+            assert!(message.contains("set"), "{message}");
+            assert!(!step
+                .events
+                .iter()
+                .any(|event| matches!(event, RuntimeEvent::StrategyDecisionProduced { .. })));
+        }
+    }
+
+    #[test]
+    fn context_does_not_expose_market_data_or_old_flat_portfolio_aliases() {
+        for expression in ["context.balance", "context.candle", "context.close"] {
+            let source = source_returning(&format!(
+                r#"
+let forbidden = {expression};
+decision::hold()
+"#
+            ));
+            let step = run_completed_tick(&source);
+            let message = strategy_error_message(&step);
+
+            assert!(
+                message.contains("Property") || message.contains("property"),
+                "{expression}: {message}"
+            );
+            assert!(!step
+                .events
+                .iter()
+                .any(|event| matches!(event, RuntimeEvent::StrategyDecisionProduced { .. })));
+        }
     }
 
     #[test]

--- a/trading-runtime/src/rhai_strategy.rs
+++ b/trading-runtime/src/rhai_strategy.rs
@@ -1,0 +1,674 @@
+//! Rhai strategy loading and hook validation for the trading runtime.
+//!
+//! This module owns compile/load-time Rhai strategy handling inside the
+//! `trading-runtime` crate. Tick execution and the full strategy-facing typed
+//! APIs are implemented in later Strategy Handling slices.
+
+use crate::StrategyDecision;
+use rhai::{Dynamic, Engine as RhaiEngine, EvalAltResult, Module, Scope, AST, INT};
+use shared::Timeframe;
+use std::{error::Error, fmt, path::Path, sync::Arc};
+
+/// Typed strategy-declared configuration returned by `strategy_config()`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StrategyConfiguration {
+    minimum_warmup: usize,
+}
+
+impl StrategyConfiguration {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn minimum_warmup(&self) -> usize {
+        self.minimum_warmup
+    }
+
+    fn with_minimum_warmup(mut self, minimum_warmup: usize) -> Self {
+        self.minimum_warmup = minimum_warmup;
+        self
+    }
+}
+
+/// Placeholder typed anchored configuration returned by `anchored_config()`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AnchoredConfiguration;
+
+impl AnchoredConfiguration {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Strategy hooks detected during Rhai strategy loading.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RhaiStrategyHooks {
+    pub has_on_tick: bool,
+    pub has_strategy_config: bool,
+    pub has_anchored_config: bool,
+}
+
+/// Runtime-owned compiled Rhai strategy and load-time metadata.
+pub struct RhaiStrategy {
+    engine: RhaiEngine,
+    ast: AST,
+    scope: Scope<'static>,
+    hooks: RhaiStrategyHooks,
+    strategy_config: StrategyConfiguration,
+    anchored_config: Option<AnchoredConfiguration>,
+}
+
+impl RhaiStrategy {
+    /// Compile and initialize a Rhai strategy from source.
+    pub fn load(source: &str) -> Result<Self, RhaiStrategyLoadError> {
+        let engine = new_rhai_engine();
+
+        let normalized_source = normalize_reserved_constructor_names(source);
+        let ast =
+            engine
+                .compile(&normalized_source)
+                .map_err(|error| RhaiStrategyLoadError::Compile {
+                    message: error.to_string(),
+                })?;
+
+        validate_required_on_tick(&ast)?;
+        validate_optional_zero_arg_hook(&ast, STRATEGY_CONFIG_HOOK)?;
+        validate_optional_zero_arg_hook(&ast, ANCHORED_CONFIG_HOOK)?;
+
+        let mut scope = Scope::new();
+        engine
+            .run_ast_with_scope(&mut scope, &ast)
+            .map_err(|error| RhaiStrategyLoadError::Init {
+                message: error.to_string(),
+            })?;
+
+        let strategy_config = if has_zero_arg_hook(&ast, STRATEGY_CONFIG_HOOK) {
+            call_typed_strategy_config(&engine, &mut scope, &ast)?
+        } else {
+            StrategyConfiguration::default()
+        };
+
+        let anchored_config = if has_zero_arg_hook(&ast, ANCHORED_CONFIG_HOOK) {
+            Some(call_typed_anchored_config(&engine, &mut scope, &ast)?)
+        } else {
+            None
+        };
+
+        let hooks = RhaiStrategyHooks {
+            has_on_tick: true,
+            has_strategy_config: has_zero_arg_hook(&ast, STRATEGY_CONFIG_HOOK),
+            has_anchored_config: has_zero_arg_hook(&ast, ANCHORED_CONFIG_HOOK),
+        };
+
+        Ok(Self {
+            engine,
+            ast,
+            scope,
+            hooks,
+            strategy_config,
+            anchored_config,
+        })
+    }
+
+    /// Load a Rhai strategy file from disk.
+    pub fn load_file(path: impl AsRef<Path>) -> Result<Self, RhaiStrategyLoadError> {
+        let source = std::fs::read_to_string(path).map_err(|error| RhaiStrategyLoadError::Io {
+            message: error.to_string(),
+        })?;
+        Self::load(&source)
+    }
+
+    pub fn hooks(&self) -> RhaiStrategyHooks {
+        self.hooks
+    }
+
+    pub fn strategy_config(&self) -> &StrategyConfiguration {
+        &self.strategy_config
+    }
+
+    pub fn anchored_config(&self) -> Option<&AnchoredConfiguration> {
+        self.anchored_config.as_ref()
+    }
+
+    /// Rhai engine with runtime-owned strategy-facing registrations.
+    pub fn engine(&self) -> &RhaiEngine {
+        &self.engine
+    }
+
+    /// Compiled Rhai AST, kept available for later warmup/indicator detection.
+    pub fn ast(&self) -> &AST {
+        &self.ast
+    }
+
+    /// Persistent Rhai scope populated by top-level declarations.
+    pub fn scope(&self) -> &Scope<'static> {
+        &self.scope
+    }
+}
+
+const ON_TICK_HOOK: &str = "on_tick";
+const STRATEGY_CONFIG_HOOK: &str = "strategy_config";
+const ANCHORED_CONFIG_HOOK: &str = "anchored_config";
+
+/// Load-time errors from Rhai strategy handling.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RhaiStrategyLoadError {
+    Io {
+        message: String,
+    },
+    Compile {
+        message: String,
+    },
+    Init {
+        message: String,
+    },
+    MissingRequiredHook {
+        expected: &'static str,
+    },
+    InvalidHookSignature {
+        hook: &'static str,
+        expected: &'static str,
+    },
+    HookEvaluation {
+        hook: &'static str,
+        message: String,
+    },
+    InvalidHookReturn {
+        hook: &'static str,
+        expected: &'static str,
+    },
+}
+
+impl fmt::Display for RhaiStrategyLoadError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io { message } => write!(formatter, "strategy file read error: {message}"),
+            Self::Compile { message } => write!(formatter, "strategy compile error: {message}"),
+            Self::Init { message } => write!(formatter, "strategy init error: {message}"),
+            Self::MissingRequiredHook { expected } => {
+                write!(formatter, "strategy must define required hook `{expected}`")
+            }
+            Self::InvalidHookSignature { hook, expected } => {
+                write!(formatter, "strategy hook `{hook}` must be `{expected}`")
+            }
+            Self::HookEvaluation { hook, message } => {
+                write!(
+                    formatter,
+                    "strategy hook `{hook}` failed at load time: {message}"
+                )
+            }
+            Self::InvalidHookReturn { hook, expected } => {
+                write!(formatter, "strategy hook `{hook}` must return {expected}")
+            }
+        }
+    }
+}
+
+impl Error for RhaiStrategyLoadError {}
+
+impl fmt::Debug for RhaiStrategy {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RhaiStrategy")
+            .field("hooks", &self.hooks)
+            .field("strategy_config", &self.strategy_config)
+            .field("anchored_config", &self.anchored_config)
+            .finish_non_exhaustive()
+    }
+}
+
+fn new_rhai_engine() -> RhaiEngine {
+    let mut engine = RhaiEngine::new();
+
+    engine.register_type_with_name::<Timeframe>("Timeframe");
+    engine.register_type_with_name::<StrategyConfiguration>("StrategyConfig");
+    engine.register_type_with_name::<AnchoredConfiguration>("AnchoredConfig");
+    engine.register_type_with_name::<StrategyDecision>("StrategyDecision");
+
+    engine.register_fn("timeframe", parse_timeframe);
+    engine.register_fn(
+        "with_minimum_warmup",
+        |config: StrategyConfiguration, minimum_warmup: INT| {
+            with_minimum_warmup(config, minimum_warmup)
+        },
+    );
+
+    engine.register_fn("__runtime_strategy_config_new", StrategyConfiguration::new);
+    engine.register_fn("__runtime_anchored_config_new", AnchoredConfiguration::new);
+
+    let mut strategy_config_module = Module::new();
+    strategy_config_module.set_native_fn("new", || Ok(StrategyConfiguration::new()));
+    engine.register_static_module("strategy_config", Arc::new(strategy_config_module));
+
+    let mut anchored_config_module = Module::new();
+    anchored_config_module.set_native_fn("new", || Ok(AnchoredConfiguration::new()));
+    engine.register_static_module("anchored_config", Arc::new(anchored_config_module));
+
+    // Minimal placeholder for loader smoke tests. Full typed decision execution
+    // is intentionally left to the Strategy Decision Rhai API issue.
+    let mut decision_module = Module::new();
+    decision_module.set_native_fn("hold", || Ok(StrategyDecision::hold()));
+    engine.register_static_module("decision", Arc::new(decision_module));
+
+    engine
+}
+
+fn normalize_reserved_constructor_names(source: &str) -> String {
+    // Rhai 1.24 reserves `new` even in module paths such as
+    // `strategy_config::new()`. Keep the strategy-facing API from ADR 0005 and
+    // lower only these approved typed constructors to private runtime function
+    // names before compilation. This is intentionally lexical enough to avoid
+    // rewriting string literals or comments.
+    const REPLACEMENTS: [(&str, &str); 2] = [
+        ("strategy_config::new(", "__runtime_strategy_config_new("),
+        ("anchored_config::new(", "__runtime_anchored_config_new("),
+    ];
+
+    let mut output = String::with_capacity(source.len());
+    let mut index = 0;
+
+    while index < source.len() {
+        let remaining = &source[index..];
+
+        if let Some((from, to)) = REPLACEMENTS
+            .iter()
+            .find(|(from, _)| remaining.starts_with(from))
+        {
+            output.push_str(to);
+            index += from.len();
+            continue;
+        }
+
+        if remaining.starts_with("//") {
+            let next = copy_until_line_end(source, index, &mut output);
+            index = next;
+            continue;
+        }
+
+        if remaining.starts_with("/*") {
+            let next = copy_until_block_comment_end(source, index, &mut output);
+            index = next;
+            continue;
+        }
+
+        if remaining.starts_with('"') {
+            let next = copy_until_string_end(source, index, &mut output);
+            index = next;
+            continue;
+        }
+
+        let character = remaining
+            .chars()
+            .next()
+            .expect("remaining source should contain a character");
+        output.push(character);
+        index += character.len_utf8();
+    }
+
+    output
+}
+
+fn copy_until_line_end(source: &str, start: usize, output: &mut String) -> usize {
+    let end = source[start..]
+        .find('\n')
+        .map(|offset| start + offset + 1)
+        .unwrap_or(source.len());
+    output.push_str(&source[start..end]);
+    end
+}
+
+fn copy_until_block_comment_end(source: &str, start: usize, output: &mut String) -> usize {
+    let end = source[start + 2..]
+        .find("*/")
+        .map(|offset| start + 2 + offset + 2)
+        .unwrap_or(source.len());
+    output.push_str(&source[start..end]);
+    end
+}
+
+fn copy_until_string_end(source: &str, start: usize, output: &mut String) -> usize {
+    let mut escaped = false;
+    let mut end = source.len();
+
+    for (offset, character) in source[start..].char_indices().skip(1) {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        match character {
+            '\\' => escaped = true,
+            '"' => {
+                end = start + offset + character.len_utf8();
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    output.push_str(&source[start..end]);
+    end
+}
+
+fn parse_timeframe(raw: &str) -> Result<Timeframe, Box<EvalAltResult>> {
+    raw.parse::<Timeframe>()
+        .map_err(|error| format!("invalid timeframe `{raw}`: {error}").into())
+}
+
+fn with_minimum_warmup(
+    config: StrategyConfiguration,
+    minimum_warmup: INT,
+) -> Result<StrategyConfiguration, Box<EvalAltResult>> {
+    let minimum_warmup = usize::try_from(minimum_warmup)
+        .map_err(|_| "minimum warmup must be a non-negative integer".to_string())?;
+
+    Ok(config.with_minimum_warmup(minimum_warmup))
+}
+
+fn validate_required_on_tick(ast: &AST) -> Result<(), RhaiStrategyLoadError> {
+    if has_hook_with_arity(ast, ON_TICK_HOOK, 2) {
+        return Ok(());
+    }
+
+    if has_any_hook(ast, ON_TICK_HOOK) {
+        return Err(RhaiStrategyLoadError::InvalidHookSignature {
+            hook: ON_TICK_HOOK,
+            expected: "fn on_tick(market, context)",
+        });
+    }
+
+    Err(RhaiStrategyLoadError::MissingRequiredHook {
+        expected: "fn on_tick(market, context)",
+    })
+}
+
+fn validate_optional_zero_arg_hook(
+    ast: &AST,
+    hook: &'static str,
+) -> Result<(), RhaiStrategyLoadError> {
+    if !has_any_hook(ast, hook) || has_zero_arg_hook(ast, hook) {
+        return Ok(());
+    }
+
+    Err(RhaiStrategyLoadError::InvalidHookSignature {
+        hook,
+        expected: match hook {
+            STRATEGY_CONFIG_HOOK => "fn strategy_config()",
+            ANCHORED_CONFIG_HOOK => "fn anchored_config()",
+            _ => "fn hook()",
+        },
+    })
+}
+
+fn call_typed_strategy_config(
+    engine: &RhaiEngine,
+    scope: &mut Scope<'static>,
+    ast: &AST,
+) -> Result<StrategyConfiguration, RhaiStrategyLoadError> {
+    let result = call_load_time_hook(engine, scope, ast, STRATEGY_CONFIG_HOOK)?;
+    result
+        .try_cast::<StrategyConfiguration>()
+        .ok_or(RhaiStrategyLoadError::InvalidHookReturn {
+            hook: STRATEGY_CONFIG_HOOK,
+            expected: "a typed StrategyConfig from `strategy_config::new()`",
+        })
+}
+
+fn call_typed_anchored_config(
+    engine: &RhaiEngine,
+    scope: &mut Scope<'static>,
+    ast: &AST,
+) -> Result<AnchoredConfiguration, RhaiStrategyLoadError> {
+    let result = call_load_time_hook(engine, scope, ast, ANCHORED_CONFIG_HOOK)?;
+    result
+        .try_cast::<AnchoredConfiguration>()
+        .ok_or(RhaiStrategyLoadError::InvalidHookReturn {
+            hook: ANCHORED_CONFIG_HOOK,
+            expected: "a typed AnchoredConfig from `anchored_config::new()`",
+        })
+}
+
+fn call_load_time_hook(
+    engine: &RhaiEngine,
+    scope: &mut Scope<'static>,
+    ast: &AST,
+    hook: &'static str,
+) -> Result<Dynamic, RhaiStrategyLoadError> {
+    engine
+        .call_fn(scope, ast, hook, ())
+        .map_err(|error| RhaiStrategyLoadError::HookEvaluation {
+            hook,
+            message: error.to_string(),
+        })
+}
+
+fn has_zero_arg_hook(ast: &AST, name: &str) -> bool {
+    has_hook_with_arity(ast, name, 0)
+}
+
+fn has_any_hook(ast: &AST, name: &str) -> bool {
+    ast.iter_functions().any(|function| function.name == name)
+}
+
+fn has_hook_with_arity(ast: &AST, name: &str, arity: usize) -> bool {
+    ast.iter_functions()
+        .any(|function| function.name == name && function.params.len() == arity)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MINIMAL: &str = r#"
+fn on_tick(market, context) {
+    decision::hold()
+}
+"#;
+
+    #[test]
+    fn loads_minimal_strategy_with_only_on_tick() {
+        let strategy = RhaiStrategy::load(MINIMAL).expect("strategy should load");
+
+        assert_eq!(
+            strategy.hooks(),
+            RhaiStrategyHooks {
+                has_on_tick: true,
+                has_strategy_config: false,
+                has_anchored_config: false,
+            }
+        );
+        assert_eq!(
+            strategy.strategy_config(),
+            &StrategyConfiguration::default()
+        );
+        assert_eq!(strategy.anchored_config(), None);
+    }
+
+    #[test]
+    fn loads_strategy_with_top_level_constants_and_typed_strategy_config() {
+        let source = r#"
+const H1 = timeframe("1h");
+
+fn strategy_config() {
+    strategy_config::new()
+        .with_minimum_warmup(200)
+}
+
+fn on_tick(market, context) {
+    decision::hold()
+}
+"#;
+
+        let strategy = RhaiStrategy::load(source).expect("strategy should load");
+
+        assert!(strategy.hooks().has_strategy_config);
+        assert_eq!(strategy.strategy_config().minimum_warmup(), 200);
+    }
+
+    #[test]
+    fn load_fails_when_required_on_tick_is_missing() {
+        let error = RhaiStrategy::load("let x = 1;").unwrap_err();
+
+        assert_eq!(
+            error,
+            RhaiStrategyLoadError::MissingRequiredHook {
+                expected: "fn on_tick(market, context)",
+            }
+        );
+        assert!(error.to_string().contains("fn on_tick(market, context)"));
+    }
+
+    #[test]
+    fn load_fails_when_on_tick_has_wrong_arity() {
+        let error = RhaiStrategy::load("fn on_tick() {}").unwrap_err();
+
+        assert_eq!(
+            error,
+            RhaiStrategyLoadError::InvalidHookSignature {
+                hook: ON_TICK_HOOK,
+                expected: "fn on_tick(market, context)",
+            }
+        );
+    }
+
+    #[test]
+    fn load_fails_for_syntax_errors() {
+        let error = RhaiStrategy::load("fn on_tick(market, context) {").unwrap_err();
+
+        assert!(matches!(error, RhaiStrategyLoadError::Compile { .. }));
+        assert!(error.to_string().contains("strategy compile error"));
+    }
+
+    #[test]
+    fn missing_optional_hooks_use_defaults() {
+        let strategy = RhaiStrategy::load(MINIMAL).expect("strategy should load");
+
+        assert_eq!(
+            strategy.strategy_config(),
+            &StrategyConfiguration::default()
+        );
+        assert!(strategy.anchored_config().is_none());
+    }
+
+    #[test]
+    fn present_anchored_config_is_called_and_validated() {
+        let source = r#"
+fn anchored_config() {
+    anchored_config::new()
+}
+
+fn on_tick(market, context) {
+    decision::hold()
+}
+"#;
+
+        let strategy = RhaiStrategy::load(source).expect("strategy should load");
+
+        assert!(strategy.hooks().has_anchored_config);
+        assert_eq!(strategy.anchored_config(), Some(&AnchoredConfiguration));
+    }
+
+    #[test]
+    fn optional_strategy_config_returning_unit_fails_load() {
+        let source = r#"
+fn strategy_config() {
+    ()
+}
+
+fn on_tick(market, context) {
+    decision::hold()
+}
+"#;
+
+        let error = RhaiStrategy::load(source).unwrap_err();
+
+        assert_eq!(
+            error,
+            RhaiStrategyLoadError::InvalidHookReturn {
+                hook: STRATEGY_CONFIG_HOOK,
+                expected: "a typed StrategyConfig from `strategy_config::new()`",
+            }
+        );
+    }
+
+    #[test]
+    fn optional_strategy_config_returning_map_fails_load_without_legacy_mapping() {
+        let source = r#"
+fn strategy_config() {
+    #{ minimum_warmup: 200 }
+}
+
+fn on_tick(market, context) {
+    decision::hold()
+}
+"#;
+
+        let error = RhaiStrategy::load(source).unwrap_err();
+
+        assert!(matches!(
+            error,
+            RhaiStrategyLoadError::InvalidHookReturn {
+                hook: STRATEGY_CONFIG_HOOK,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn optional_anchored_config_returning_map_fails_load_without_legacy_mapping() {
+        let source = r#"
+fn anchored_config() {
+    #{}
+}
+
+fn on_tick(market, context) {
+    decision::hold()
+}
+"#;
+
+        let error = RhaiStrategy::load(source).unwrap_err();
+
+        assert!(matches!(
+            error,
+            RhaiStrategyLoadError::InvalidHookReturn {
+                hook: ANCHORED_CONFIG_HOOK,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn reserved_constructor_normalization_preserves_strings_and_comments() {
+        let source = r#"
+// strategy_config::new(
+const LABEL = "strategy_config::new(";
+/* anchored_config::new( */
+fn strategy_config() { strategy_config::new() }
+fn anchored_config() { anchored_config::new() }
+"#;
+
+        let normalized = normalize_reserved_constructor_names(source);
+
+        assert!(normalized.contains("// strategy_config::new("));
+        assert!(normalized.contains("\"strategy_config::new(\""));
+        assert!(normalized.contains("/* anchored_config::new( */"));
+        assert!(normalized.contains("fn strategy_config() { __runtime_strategy_config_new() }"));
+        assert!(normalized.contains("fn anchored_config() { __runtime_anchored_config_new() }"));
+    }
+
+    #[test]
+    fn invalid_top_level_timeframe_fails_initialization() {
+        let source = r#"
+const BAD = timeframe("15min");
+
+fn on_tick(market, context) {
+    decision::hold()
+}
+"#;
+
+        let error = RhaiStrategy::load(source).unwrap_err();
+
+        assert!(matches!(error, RhaiStrategyLoadError::Init { .. }));
+        assert!(error.to_string().contains("invalid timeframe"));
+    }
+}

--- a/trading-runtime/src/rhai_strategy.rs
+++ b/trading-runtime/src/rhai_strategy.rs
@@ -6,34 +6,14 @@
 //! tick boundary. Secondary Market View access is implemented in a later slice.
 
 use crate::{
-    RuntimePortfolioSnapshot, StrategyDecision, StrategyError, StrategyHandler, StrategyState,
-    StrategyStateValue, StrategyTickInput, StrategyTickResult,
+    RuntimePortfolioSnapshot, SecondaryTimeframeConfig, StrategyConfiguration, StrategyDecision,
+    StrategyError, StrategyHandler, StrategyState, StrategyStateValue, StrategyTickInput,
+    StrategyTickResult,
 };
 use indicators::trend::sma::sma;
 use rhai::{Dynamic, Engine as RhaiEngine, EvalAltResult, Module, Scope, AST, FLOAT, INT};
 use shared::{Candle, Position, Timeframe};
 use std::{error::Error, fmt, path::Path, sync::Arc};
-
-/// Typed strategy-declared configuration returned by `strategy_config()`.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct StrategyConfiguration {
-    minimum_warmup: usize,
-}
-
-impl StrategyConfiguration {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn minimum_warmup(&self) -> usize {
-        self.minimum_warmup
-    }
-
-    fn with_minimum_warmup(mut self, minimum_warmup: usize) -> Self {
-        self.minimum_warmup = minimum_warmup;
-        self
-    }
-}
 
 /// Placeholder typed anchored configuration returned by `anchored_config()`.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -353,6 +333,7 @@ fn new_rhai_engine() -> RhaiEngine {
 
     engine.register_type_with_name::<Timeframe>("Timeframe");
     engine.register_type_with_name::<StrategyConfiguration>("StrategyConfig");
+    engine.register_type_with_name::<SecondaryTimeframeConfig>("SecondaryConfig");
     engine.register_type_with_name::<AnchoredConfiguration>("AnchoredConfig");
     engine.register_type_with_name::<StrategyDecision>("StrategyDecision");
     engine.register_type_with_name::<RhaiMarketView>("MarketView");
@@ -375,6 +356,8 @@ fn new_rhai_engine() -> RhaiEngine {
             with_minimum_warmup(config, minimum_warmup)
         },
     );
+    engine.register_fn("with_secondary", with_secondary);
+    engine.register_fn("with_max_missing_candles", with_max_missing_candles);
 
     engine.register_fn("__runtime_strategy_config_new", StrategyConfiguration::new);
     engine.register_fn("__runtime_anchored_config_new", AnchoredConfiguration::new);
@@ -382,6 +365,15 @@ fn new_rhai_engine() -> RhaiEngine {
     let mut strategy_config_module = Module::new();
     strategy_config_module.set_native_fn("new", || Ok(StrategyConfiguration::new()));
     engine.register_static_module("strategy_config", Arc::new(strategy_config_module));
+
+    let mut secondary_module = Module::new();
+    secondary_module.set_native_fn("required", |timeframe: Timeframe| {
+        Ok(SecondaryTimeframeConfig::required(timeframe, 0))
+    });
+    secondary_module.set_native_fn("optional", |timeframe: Timeframe| {
+        Ok(SecondaryTimeframeConfig::optional(timeframe, 0))
+    });
+    engine.register_static_module("secondary", Arc::new(secondary_module));
 
     let mut anchored_config_module = Module::new();
     anchored_config_module.set_native_fn("new", || Ok(AnchoredConfiguration::new()));
@@ -742,6 +734,24 @@ fn with_minimum_warmup(
     Ok(config.with_minimum_warmup(minimum_warmup))
 }
 
+fn with_secondary(
+    config: StrategyConfiguration,
+    secondary: SecondaryTimeframeConfig,
+) -> StrategyConfiguration {
+    config.with_secondary(secondary)
+}
+
+fn with_max_missing_candles(
+    mut secondary: SecondaryTimeframeConfig,
+    max_missing_candles: INT,
+) -> Result<SecondaryTimeframeConfig, Box<EvalAltResult>> {
+    secondary.max_missing_candles = u32::try_from(max_missing_candles).map_err(|_| {
+        "max missing candles must be a non-negative integer fitting u32".to_string()
+    })?;
+
+    Ok(secondary)
+}
+
 fn with_stop_loss(
     decision: StrategyDecision,
     stop_loss: FLOAT,
@@ -875,8 +885,8 @@ fn has_hook_with_arity(ast: &AST, name: &str, arity: usize) -> bool {
 mod tests {
     use super::*;
     use crate::{
-        ExecutionAction, IgnoredDecisionReason, MarketInput, PortfolioState, RuntimeEvent,
-        StrategyDecisionIntent, TradingRuntime,
+        ExecutionAction, IgnoredDecisionReason, MarketInput, PortfolioState, RuntimeConfig,
+        RuntimeEvent, SecondaryReadiness, StrategyDecisionIntent, TradingRuntime,
     };
     use shared::{Candle, Timeframe};
 
@@ -1316,6 +1326,195 @@ fn on_tick(market, context) {
 
         assert!(strategy.hooks().has_strategy_config);
         assert_eq!(strategy.strategy_config().minimum_warmup(), 200);
+    }
+
+    #[test]
+    fn typed_strategy_config_extracts_required_and_optional_secondaries() {
+        let source = r#"
+const H1 = timeframe("1h");
+const D1 = timeframe("1d");
+
+fn strategy_config() {
+    strategy_config::new()
+        .with_minimum_warmup(200)
+        .with_secondary(
+            secondary::required(H1)
+                .with_max_missing_candles(1)
+        )
+        .with_secondary(
+            secondary::optional(D1)
+                .with_max_missing_candles(0)
+        )
+}
+
+fn on_tick(market, context) {
+    decision::hold()
+}
+"#;
+
+        let strategy = RhaiStrategy::load(source).expect("strategy should load");
+
+        assert_eq!(strategy.strategy_config().minimum_warmup(), 200);
+        assert_eq!(
+            strategy.strategy_config().secondary_timeframes(),
+            &[
+                SecondaryTimeframeConfig::required(Timeframe::hours(1), 1),
+                SecondaryTimeframeConfig::optional(Timeframe::days(1), 0),
+            ]
+        );
+    }
+
+    #[test]
+    fn runtime_config_merge_adds_strategy_only_secondaries() {
+        let source = r#"
+const H1 = timeframe("1h");
+const D1 = timeframe("1d");
+
+fn strategy_config() {
+    strategy_config::new()
+        .with_secondary(secondary::required(H1).with_max_missing_candles(1))
+        .with_secondary(secondary::optional(D1).with_max_missing_candles(0))
+}
+
+fn on_tick(market, context) {
+    decision::hold()
+}
+"#;
+        let strategy = RhaiStrategy::load(source).expect("strategy should load");
+        let run_config = RuntimeConfig::single_timeframe("BTC-USD", Timeframe::minutes(1));
+
+        let resolved = run_config.merge_strategy_config(strategy.strategy_config());
+
+        assert_eq!(resolved.runtime_asset, "BTC-USD");
+        assert_eq!(resolved.primary_timeframe, Timeframe::minutes(1));
+        assert_eq!(
+            resolved.secondary_timeframes,
+            vec![
+                SecondaryTimeframeConfig::required(Timeframe::hours(1), 1),
+                SecondaryTimeframeConfig::optional(Timeframe::days(1), 0),
+            ]
+        );
+    }
+
+    #[test]
+    fn runtime_config_merge_preserves_run_config_only_secondaries() {
+        let run_config = RuntimeConfig::with_secondary_configs(
+            "BTC-USD",
+            Timeframe::minutes(1),
+            [SecondaryTimeframeConfig::optional(Timeframe::hours(1), 2)],
+        );
+
+        let resolved = run_config.merge_strategy_config(&StrategyConfiguration::default());
+
+        assert_eq!(resolved, run_config);
+    }
+
+    #[test]
+    fn runtime_config_wins_secondary_conflicts() {
+        let source = r#"
+const H1 = timeframe("1h");
+
+fn strategy_config() {
+    strategy_config::new()
+        .with_secondary(secondary::required(H1).with_max_missing_candles(1))
+}
+
+fn on_tick(market, context) {
+    decision::hold()
+}
+"#;
+        let strategy = RhaiStrategy::load(source).expect("strategy should load");
+        let run_config = RuntimeConfig::with_secondary_configs(
+            "BTC-USD",
+            Timeframe::minutes(1),
+            [SecondaryTimeframeConfig::optional(Timeframe::hours(1), 0)],
+        );
+
+        let resolved = run_config.merge_strategy_config(strategy.strategy_config());
+
+        assert_eq!(resolved.runtime_asset, "BTC-USD");
+        assert_eq!(resolved.primary_timeframe, Timeframe::minutes(1));
+        assert_eq!(
+            resolved.secondary_timeframes,
+            vec![SecondaryTimeframeConfig::optional(Timeframe::hours(1), 0)]
+        );
+        assert_eq!(
+            resolved.secondary_timeframes[0].readiness,
+            SecondaryReadiness::Optional
+        );
+    }
+
+    #[test]
+    fn strategy_config_cannot_change_runtime_asset_or_primary_timeframe() {
+        for forbidden in [
+            r#"strategy_config::new().with_runtime_asset("ETH-USD")"#,
+            r#"strategy_config::new().with_primary_timeframe(timeframe("1h"))"#,
+        ] {
+            let source = format!(
+                r#"
+fn strategy_config() {{
+    {forbidden}
+}}
+
+fn on_tick(market, context) {{
+    decision::hold()
+}}
+"#
+            );
+
+            let error = RhaiStrategy::load(&source).unwrap_err();
+
+            assert!(
+                matches!(error, RhaiStrategyLoadError::HookEvaluation { .. }),
+                "{forbidden}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_timeframe_in_strategy_config_fails_load() {
+        let source = r#"
+fn strategy_config() {
+    strategy_config::new()
+        .with_secondary(secondary::required(timeframe("15min")))
+}
+
+fn on_tick(market, context) {
+    decision::hold()
+}
+"#;
+
+        let error = RhaiStrategy::load(source).unwrap_err();
+
+        assert!(matches!(
+            error,
+            RhaiStrategyLoadError::HookEvaluation { .. }
+        ));
+        assert!(error.to_string().contains("invalid timeframe"));
+    }
+
+    #[test]
+    fn invalid_secondary_missing_candle_tolerance_fails_load() {
+        let source = r#"
+const H1 = timeframe("1h");
+
+fn strategy_config() {
+    strategy_config::new()
+        .with_secondary(secondary::required(H1).with_max_missing_candles(-1))
+}
+
+fn on_tick(market, context) {
+    decision::hold()
+}
+"#;
+
+        let error = RhaiStrategy::load(source).unwrap_err();
+
+        assert!(matches!(
+            error,
+            RhaiStrategyLoadError::HookEvaluation { .. }
+        ));
+        assert!(error.to_string().contains("max missing candles"));
     }
 
     #[test]

--- a/trading-runtime/src/rhai_strategy.rs
+++ b/trading-runtime/src/rhai_strategy.rs
@@ -8,24 +8,16 @@
 //! stale for the current Strategy Tick.
 
 use crate::{
+    AnchoredConfiguration, AnchoredEvaluatorConfiguration, AnchoredOutput, AnchoredOutputs,
+    AnchoredRuntime, MarketState, PivotDetectorConfiguration, PivotEvent, PivotSide,
     RuntimePortfolioSnapshot, SecondaryTimeframeConfig, StrategyConfiguration, StrategyDecision,
     StrategyError, StrategyHandler, StrategyState, StrategyStateValue, StrategyTickInput,
     StrategyTickResult,
 };
-use indicators::trend::sma::sma;
+use indicators::{anchored::evaluators::TrendLine, trend::sma::sma};
 use rhai::{Dynamic, Engine as RhaiEngine, EvalAltResult, Module, Scope, AST, FLOAT, INT};
 use shared::{Candle, Position, Timeframe};
 use std::{collections::HashMap, error::Error, fmt, path::Path, sync::Arc};
-
-/// Placeholder typed anchored configuration returned by `anchored_config()`.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct AnchoredConfiguration;
-
-impl AnchoredConfiguration {
-    pub fn new() -> Self {
-        Self
-    }
-}
 
 /// Strategy hooks detected during Rhai strategy loading.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -43,6 +35,7 @@ pub struct RhaiStrategy {
     hooks: RhaiStrategyHooks,
     strategy_config: StrategyConfiguration,
     anchored_config: Option<AnchoredConfiguration>,
+    anchored_runtime: Option<AnchoredRuntime>,
 }
 
 #[derive(Debug, Clone)]
@@ -50,10 +43,14 @@ struct RhaiMarketView {
     current: RhaiCandle,
     primary_history: RhaiCandleHistory,
     histories_by_timeframe: HashMap<Timeframe, Option<RhaiCandleHistory>>,
+    anchored_outputs: Option<AnchoredOutputs>,
 }
 
 impl RhaiMarketView {
-    fn from_runtime(market: &crate::MarketView<'_>) -> Self {
+    fn from_runtime(
+        market: &crate::MarketView<'_>,
+        anchored_outputs: Option<AnchoredOutputs>,
+    ) -> Self {
         let primary_history = RhaiCandleHistory::new(market.primary_history().to_vec());
         let mut view = Self {
             current: RhaiCandle::new(market.primary_candle().clone()),
@@ -62,6 +59,7 @@ impl RhaiMarketView {
                 market.primary_timeframe(),
                 Some(primary_history),
             )]),
+            anchored_outputs,
         };
 
         for timeframe in market.configured_timeframes() {
@@ -136,6 +134,28 @@ impl RhaiCandleHistory {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct RhaiTrendLine {
+    line: TrendLine,
+}
+
+impl RhaiTrendLine {
+    fn new(line: TrendLine) -> Self {
+        Self { line }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RhaiPivotEvent {
+    event: PivotEvent,
+}
+
+impl RhaiPivotEvent {
+    fn new(event: PivotEvent) -> Self {
+        Self { event }
+    }
+}
+
 #[derive(Debug, Clone)]
 struct RhaiStrategyContext {
     portfolio: RhaiPortfolioSnapshot,
@@ -182,8 +202,32 @@ impl RhaiPosition {
 }
 
 impl StrategyHandler for RhaiStrategy {
+    fn on_market_input_accepted(
+        &mut self,
+        market_state: &MarketState,
+        candle: &Candle,
+        primary_timeframe: Timeframe,
+    ) {
+        let Some(runtime) = &mut self.anchored_runtime else {
+            return;
+        };
+        if candle.timeframe != primary_timeframe {
+            return;
+        }
+        let Some(history) = market_state.history(primary_timeframe) else {
+            return;
+        };
+
+        runtime.on_market_input_accepted(candle, history);
+    }
+
     fn on_tick(&mut self, input: StrategyTickInput<'_>) -> StrategyTickResult {
-        let market = RhaiMarketView::from_runtime(&input.market);
+        let market = RhaiMarketView::from_runtime(
+            &input.market,
+            self.anchored_runtime
+                .as_ref()
+                .map(|runtime| runtime.outputs().clone()),
+        );
         let context =
             RhaiStrategyContext::from_runtime(input.context.portfolio, input.context.state);
 
@@ -246,6 +290,15 @@ impl RhaiStrategy {
         } else {
             None
         };
+        let anchored_runtime = anchored_config
+            .as_ref()
+            .filter(|config| !config.is_empty())
+            .map(AnchoredRuntime::from_config)
+            .transpose()
+            .map_err(|error| RhaiStrategyLoadError::HookEvaluation {
+                hook: ANCHORED_CONFIG_HOOK,
+                message: error.to_string(),
+            })?;
 
         let hooks = RhaiStrategyHooks {
             has_on_tick: true,
@@ -260,6 +313,7 @@ impl RhaiStrategy {
             hooks,
             strategy_config,
             anchored_config,
+            anchored_runtime,
         })
     }
 
@@ -377,6 +431,11 @@ fn new_rhai_engine() -> RhaiEngine {
     engine.register_type_with_name::<StrategyConfiguration>("StrategyConfig");
     engine.register_type_with_name::<SecondaryTimeframeConfig>("SecondaryConfig");
     engine.register_type_with_name::<AnchoredConfiguration>("AnchoredConfig");
+    engine.register_type_with_name::<PivotDetectorConfiguration>("PivotDetectorConfig");
+    engine.register_type_with_name::<AnchoredEvaluatorConfiguration>("AnchoredEvaluatorConfig");
+    engine.register_type_with_name::<PivotSide>("PivotSide");
+    engine.register_type_with_name::<RhaiTrendLine>("TrendLine");
+    engine.register_type_with_name::<RhaiPivotEvent>("PivotEvent");
     engine.register_type_with_name::<StrategyDecision>("StrategyDecision");
     engine.register_type_with_name::<RhaiMarketView>("MarketView");
     engine.register_type_with_name::<RhaiCandle>("Candle");
@@ -389,6 +448,7 @@ fn new_rhai_engine() -> RhaiEngine {
     register_market_view_api(&mut engine);
     register_strategy_context_api(&mut engine);
     register_indicator_api(&mut engine);
+    register_anchored_api(&mut engine);
 
     engine.register_fn("timeframe", parse_timeframe);
     engine.register_fn("==", |left: Timeframe, right: Timeframe| left == right);
@@ -400,9 +460,19 @@ fn new_rhai_engine() -> RhaiEngine {
     );
     engine.register_fn("with_secondary", with_secondary);
     engine.register_fn("with_max_missing_candles", with_max_missing_candles);
+    engine.register_fn("with_detector", anchored_config_with_detector);
+    engine.register_fn("with_evaluator", anchored_config_with_evaluator);
+    engine.register_fn("with_left_bars", pivot_detector_with_left_bars);
+    engine.register_fn("with_right_bars", pivot_detector_with_right_bars);
+    engine.register_fn("with_side", anchored_evaluator_with_side);
+    engine.register_fn("with_pivot_buffer", anchored_evaluator_with_pivot_buffer);
+    engine.register_fn("with_tolerance", anchored_evaluator_with_tolerance);
+    engine.register_fn("with_min_touches", anchored_evaluator_with_min_touches);
+    engine.register_fn("with_max_lines", anchored_evaluator_with_max_lines);
 
     engine.register_fn("__runtime_strategy_config_new", StrategyConfiguration::new);
     engine.register_fn("__runtime_anchored_config_new", AnchoredConfiguration::new);
+    engine.register_fn("__runtime_pivot_detector_new", pivot_detector_new);
 
     let mut strategy_config_module = Module::new();
     strategy_config_module.set_native_fn("new", || Ok(StrategyConfiguration::new()));
@@ -420,6 +490,24 @@ fn new_rhai_engine() -> RhaiEngine {
     let mut anchored_config_module = Module::new();
     anchored_config_module.set_native_fn("new", || Ok(AnchoredConfiguration::new()));
     engine.register_static_module("anchored_config", Arc::new(anchored_config_module));
+
+    let mut pivot_detector_module = Module::new();
+    pivot_detector_module.set_native_fn("new", |id: &str| Ok(PivotDetectorConfiguration::new(id)));
+    engine.register_static_module("pivot_detector", Arc::new(pivot_detector_module));
+
+    let mut pivot_side_module = Module::new();
+    pivot_side_module.set_native_fn("high", || Ok(PivotSide::high()));
+    pivot_side_module.set_native_fn("low", || Ok(PivotSide::low()));
+    engine.register_static_module("pivot_side", Arc::new(pivot_side_module));
+
+    let mut anchored_module = Module::new();
+    anchored_module.set_native_fn("trendline", |expose_as: &str, pivot_source: &str| {
+        Ok(AnchoredEvaluatorConfiguration::trendline(
+            expose_as,
+            pivot_source,
+        ))
+    });
+    engine.register_static_module("anchored", Arc::new(anchored_module));
 
     let mut decision_module = Module::new();
     decision_module.set_native_fn("hold", || Ok(StrategyDecision::hold()));
@@ -452,9 +540,10 @@ fn normalize_reserved_constructor_names(source: &str) -> String {
     // lower only these approved typed constructors to private runtime function
     // names before compilation. This is intentionally lexical enough to avoid
     // rewriting string literals or comments.
-    const REPLACEMENTS: [(&str, &str); 2] = [
+    const REPLACEMENTS: [(&str, &str); 3] = [
         ("strategy_config::new(", "__runtime_strategy_config_new("),
         ("anchored_config::new(", "__runtime_anchored_config_new("),
+        ("pivot_detector::new(", "__runtime_pivot_detector_new("),
     ];
 
     let mut output = String::with_capacity(source.len());
@@ -677,6 +766,76 @@ fn register_market_view_api(engine: &mut RhaiEngine) {
     });
 }
 
+fn register_anchored_api(engine: &mut RhaiEngine) {
+    engine.register_fn(
+        "anchored",
+        |market: &mut RhaiMarketView, name: &str| -> Dynamic {
+            let Some(outputs) = &market.anchored_outputs else {
+                return Dynamic::UNIT;
+            };
+
+            match outputs.values.get(name) {
+                Some(AnchoredOutput::Trendlines(lines)) => {
+                    let lines: rhai::Array = lines
+                        .iter()
+                        .copied()
+                        .map(|line| Dynamic::from(RhaiTrendLine::new(line)))
+                        .collect();
+                    Dynamic::from(lines)
+                }
+                None => Dynamic::UNIT,
+            }
+        },
+    );
+    engine.register_fn(
+        "last_pivot",
+        |market: &mut RhaiMarketView, detector_id: &str, side: PivotSide| -> Dynamic {
+            let Some(outputs) = &market.anchored_outputs else {
+                return Dynamic::UNIT;
+            };
+
+            let event = match side {
+                PivotSide::High => outputs.last_pivot_high.get(detector_id),
+                PivotSide::Low => outputs.last_pivot_low.get(detector_id),
+            };
+
+            event
+                .copied()
+                .map(|event| Dynamic::from(RhaiPivotEvent::new(event)))
+                .unwrap_or(Dynamic::UNIT)
+        },
+    );
+
+    engine.register_get("slope", |line: &mut RhaiTrendLine| line.line.slope);
+    engine.register_get("intercept", |line: &mut RhaiTrendLine| line.line.intercept);
+    engine.register_get("touches", |line: &mut RhaiTrendLine| {
+        line.line.touches as INT
+    });
+    engine.register_get("anchor_start_bar", |line: &mut RhaiTrendLine| {
+        line.line.anchor_start_bar as INT
+    });
+    engine.register_get("anchor_end_bar", |line: &mut RhaiTrendLine| {
+        line.line.anchor_end_bar as INT
+    });
+    engine.register_get("side", |line: &mut RhaiTrendLine| match line.line.side {
+        indicators::anchored::evaluators::TrendlineSide::Resistance => "resistance".to_string(),
+        indicators::anchored::evaluators::TrendlineSide::Support => "support".to_string(),
+    });
+    engine.register_fn("y_at", |line: &mut RhaiTrendLine, bar: INT| {
+        line.line.y_at(bar.max(0) as u64)
+    });
+
+    engine.register_get("bar", |pivot: &mut RhaiPivotEvent| pivot.event.bar as INT);
+    engine.register_get("price", |pivot: &mut RhaiPivotEvent| pivot.event.price);
+    engine.register_get("volume", |pivot: &mut RhaiPivotEvent| pivot.event.volume);
+    engine.register_get("side", |pivot: &mut RhaiPivotEvent| {
+        match pivot.event.side {
+            PivotSide::High => "high".to_string(),
+            PivotSide::Low => "low".to_string(),
+        }
+    });
+}
+
 fn register_indicator_api(engine: &mut RhaiEngine) {
     let mut indicators_module = Module::new();
     indicators_module.set_native_fn(
@@ -817,6 +976,122 @@ fn with_max_missing_candles(
     Ok(secondary)
 }
 
+fn pivot_detector_new(id: &str) -> PivotDetectorConfiguration {
+    PivotDetectorConfiguration::new(id)
+}
+
+fn anchored_config_with_detector(
+    config: AnchoredConfiguration,
+    detector: PivotDetectorConfiguration,
+) -> Result<AnchoredConfiguration, Box<EvalAltResult>> {
+    ensure_non_empty_label(detector_id(&detector), "pivot detector id")?;
+    Ok(config.with_detector(detector))
+}
+
+fn anchored_config_with_evaluator(
+    config: AnchoredConfiguration,
+    evaluator: AnchoredEvaluatorConfiguration,
+) -> Result<AnchoredConfiguration, Box<EvalAltResult>> {
+    ensure_non_empty_label(evaluator_name(&evaluator), "anchored evaluator name")?;
+    ensure_non_empty_label(
+        evaluator_source(&evaluator),
+        "anchored evaluator pivot source",
+    )?;
+    Ok(config.with_evaluator(evaluator))
+}
+
+fn pivot_detector_with_left_bars(
+    detector: PivotDetectorConfiguration,
+    left_bars: INT,
+) -> Result<PivotDetectorConfiguration, Box<EvalAltResult>> {
+    let left_bars = positive_usize(left_bars, "left_bars")?;
+    Ok(detector.with_left_bars(left_bars))
+}
+
+fn pivot_detector_with_right_bars(
+    detector: PivotDetectorConfiguration,
+    right_bars: INT,
+) -> Result<PivotDetectorConfiguration, Box<EvalAltResult>> {
+    let right_bars = positive_usize(right_bars, "right_bars")?;
+    Ok(detector.with_right_bars(right_bars))
+}
+
+fn anchored_evaluator_with_side(
+    evaluator: AnchoredEvaluatorConfiguration,
+    side: PivotSide,
+) -> AnchoredEvaluatorConfiguration {
+    evaluator.with_side(side)
+}
+
+fn anchored_evaluator_with_pivot_buffer(
+    evaluator: AnchoredEvaluatorConfiguration,
+    pivot_buffer: INT,
+) -> Result<AnchoredEvaluatorConfiguration, Box<EvalAltResult>> {
+    let pivot_buffer = positive_usize(pivot_buffer, "pivot_buffer")?;
+    if pivot_buffer < 3 {
+        return Err("pivot_buffer must be >= 3".into());
+    }
+    Ok(evaluator.with_pivot_buffer(pivot_buffer))
+}
+
+fn anchored_evaluator_with_tolerance(
+    evaluator: AnchoredEvaluatorConfiguration,
+    tolerance: FLOAT,
+) -> Result<AnchoredEvaluatorConfiguration, Box<EvalAltResult>> {
+    if !(tolerance.is_finite() && tolerance > 0.0 && tolerance < 0.5) {
+        return Err("tolerance must be finite and in (0.0, 0.5)".into());
+    }
+    Ok(evaluator.with_tolerance(tolerance))
+}
+
+fn anchored_evaluator_with_min_touches(
+    evaluator: AnchoredEvaluatorConfiguration,
+    min_touches: INT,
+) -> Result<AnchoredEvaluatorConfiguration, Box<EvalAltResult>> {
+    let min_touches = u32::try_from(min_touches)
+        .map_err(|_| "min_touches must be a non-negative integer fitting u32".to_string())?;
+    if min_touches < 3 {
+        return Err("min_touches must be >= 3".into());
+    }
+    Ok(evaluator.with_min_touches(min_touches))
+}
+
+fn anchored_evaluator_with_max_lines(
+    evaluator: AnchoredEvaluatorConfiguration,
+    max_lines: INT,
+) -> Result<AnchoredEvaluatorConfiguration, Box<EvalAltResult>> {
+    let max_lines = positive_usize(max_lines, "max_lines")?;
+    Ok(evaluator.with_max_lines(max_lines))
+}
+
+fn positive_usize(value: INT, name: &str) -> Result<usize, Box<EvalAltResult>> {
+    let value = usize::try_from(value).map_err(|_| format!("{name} must be a positive integer"))?;
+    if value == 0 {
+        return Err(format!("{name} must be a positive integer").into());
+    }
+    Ok(value)
+}
+
+fn ensure_non_empty_label(value: &str, name: &str) -> Result<(), Box<EvalAltResult>> {
+    if value.is_empty() {
+        Err(format!("{name} must not be empty").into())
+    } else {
+        Ok(())
+    }
+}
+
+fn detector_id(detector: &PivotDetectorConfiguration) -> &str {
+    detector.id()
+}
+
+fn evaluator_name(evaluator: &AnchoredEvaluatorConfiguration) -> &str {
+    evaluator.expose_as()
+}
+
+fn evaluator_source(evaluator: &AnchoredEvaluatorConfiguration) -> &str {
+    evaluator.pivot_source()
+}
+
 fn with_stop_loss(
     decision: StrategyDecision,
     stop_loss: FLOAT,
@@ -911,12 +1186,19 @@ fn call_typed_anchored_config(
     ast: &AST,
 ) -> Result<AnchoredConfiguration, RhaiStrategyLoadError> {
     let result = call_load_time_hook(engine, scope, ast, ANCHORED_CONFIG_HOOK)?;
-    result
-        .try_cast::<AnchoredConfiguration>()
-        .ok_or(RhaiStrategyLoadError::InvalidHookReturn {
+    let config = result.try_cast::<AnchoredConfiguration>().ok_or(
+        RhaiStrategyLoadError::InvalidHookReturn {
             hook: ANCHORED_CONFIG_HOOK,
             expected: "a typed AnchoredConfig from `anchored_config::new()`",
-        })
+        },
+    )?;
+    config
+        .validate()
+        .map_err(|error| RhaiStrategyLoadError::HookEvaluation {
+            hook: ANCHORED_CONFIG_HOOK,
+            message: error.to_string(),
+        })?;
+    Ok(config)
 }
 
 fn call_load_time_hook(
@@ -966,12 +1248,23 @@ fn on_tick(market, context) {
     }
 
     fn candle_at(close: f64, timestamp: i64, timeframe: Timeframe) -> Candle {
+        candle_ohlc_at(close, close, close, close, timestamp, timeframe)
+    }
+
+    fn candle_ohlc_at(
+        open: f64,
+        high: f64,
+        low: f64,
+        close: f64,
+        timestamp: i64,
+        timeframe: Timeframe,
+    ) -> Candle {
         Candle {
             timestamp,
             symbol: "BTC-USD".into(),
-            open: close,
-            high: close,
-            low: close,
+            open,
+            high,
+            low,
             close,
             volume: 1_000.0,
             timeframe,
@@ -2060,6 +2353,15 @@ fn on_tick(market, context) {
         let source = r#"
 fn anchored_config() {
     anchored_config::new()
+        .with_detector(
+            pivot_detector::new("swing")
+                .with_left_bars(1)
+                .with_right_bars(1)
+        )
+        .with_evaluator(
+            anchored::trendline("trend", "swing")
+                .with_side(pivot_side::high())
+        )
 }
 
 fn on_tick(market, context) {
@@ -2068,9 +2370,211 @@ fn on_tick(market, context) {
 "#;
 
         let strategy = RhaiStrategy::load(source).expect("strategy should load");
+        let config = strategy
+            .anchored_config()
+            .expect("anchored config should load");
 
         assert!(strategy.hooks().has_anchored_config);
-        assert_eq!(strategy.anchored_config(), Some(&AnchoredConfiguration));
+        assert_eq!(config.detectors().len(), 1);
+        assert_eq!(config.evaluators().len(), 1);
+    }
+
+    #[test]
+    fn missing_anchored_config_loads_and_market_outputs_are_unit() {
+        let source = source_returning(
+            r#"
+let lines = market.anchored("trend");
+let pivot = market.last_pivot("swing", pivot_side::high());
+if lines == () && pivot == () {
+    decision::open_long(1.0)
+} else {
+    decision::hold()
+}
+"#,
+        );
+
+        let step = run_completed_tick(&source);
+
+        assert_eq!(produced_decision(&step), StrategyDecision::open_long(1.0));
+    }
+
+    #[test]
+    fn invalid_typed_anchored_config_fails_load() {
+        let source = r#"
+fn anchored_config() {
+    anchored_config::new()
+        .with_detector(pivot_detector::new("swing"))
+        .with_detector(pivot_detector::new("swing"))
+        .with_evaluator(anchored::trendline("trend", "swing"))
+}
+
+fn on_tick(market, context) {
+    decision::hold()
+}
+"#;
+
+        let error = RhaiStrategy::load(source).unwrap_err();
+
+        assert!(matches!(
+            error,
+            RhaiStrategyLoadError::HookEvaluation {
+                hook: ANCHORED_CONFIG_HOOK,
+                ..
+            }
+        ));
+        assert!(error.to_string().contains("duplicate detector id"));
+    }
+
+    #[test]
+    fn invalid_pivot_detector_bars_fail_load() {
+        let source = r#"
+fn anchored_config() {
+    anchored_config::new()
+        .with_detector(pivot_detector::new("swing").with_left_bars(0))
+}
+
+fn on_tick(market, context) {
+    decision::hold()
+}
+"#;
+
+        let error = RhaiStrategy::load(source).unwrap_err();
+
+        assert!(matches!(
+            error,
+            RhaiStrategyLoadError::HookEvaluation {
+                hook: ANCHORED_CONFIG_HOOK,
+                ..
+            }
+        ));
+        assert!(error.to_string().contains("left_bars"));
+    }
+
+    #[test]
+    fn anchored_pivot_outputs_update_from_warmup_market_state_and_are_visible_on_market_view() {
+        let source = r#"
+fn anchored_config() {
+    anchored_config::new()
+        .with_detector(
+            pivot_detector::new("swing")
+                .with_left_bars(1)
+                .with_right_bars(1)
+        )
+}
+
+fn on_tick(market, context) {
+    let pivot = market.last_pivot("swing", pivot_side::high());
+    if pivot != () && pivot.bar == 1 && pivot.price == 3.0 && pivot.side == "high" {
+        decision::open_long(1.0)
+    } else {
+        decision::hold()
+    }
+}
+"#;
+        let strategy = RhaiStrategy::load(source).expect("strategy should load");
+        let mut runtime = TradingRuntime::new(PortfolioState::new(1_000.0), 3, strategy);
+
+        for (index, high) in [1.0, 3.0, 1.0].into_iter().enumerate() {
+            runtime
+                .on_market_input(MarketInput::WarmupCandle(candle_ohlc_at(
+                    high,
+                    high,
+                    high,
+                    high,
+                    index as i64,
+                    Timeframe::minutes(1),
+                )))
+                .expect("warmup candle should be accepted");
+        }
+        let step = runtime
+            .on_market_input(MarketInput::CompletedCandle(candle_ohlc_at(
+                1.0,
+                1.0,
+                1.0,
+                1.0,
+                3,
+                Timeframe::minutes(1),
+            )))
+            .expect("completed primary candle should be accepted");
+
+        assert_eq!(produced_decision(&step), StrategyDecision::open_long(1.0));
+    }
+
+    #[test]
+    fn market_anchored_returns_trendline_output_from_runtime_market_state() {
+        let source = r#"
+fn anchored_config() {
+    anchored_config::new()
+        .with_detector(
+            pivot_detector::new("swing")
+                .with_left_bars(1)
+                .with_right_bars(1)
+        )
+        .with_evaluator(
+            anchored::trendline("trend", "swing")
+                .with_side(pivot_side::high())
+                .with_pivot_buffer(3)
+                .with_min_touches(3)
+                .with_max_lines(1)
+        )
+}
+
+fn on_tick(market, context) {
+    let lines = market.anchored("trend");
+    if lines != () && lines.len() == 1 && lines[0].touches == 3 && lines[0].side == "resistance" {
+        decision::open_long(1.0)
+    } else {
+        decision::hold()
+    }
+}
+"#;
+        let strategy = RhaiStrategy::load(source).expect("strategy should load");
+        let mut runtime = TradingRuntime::new(PortfolioState::new(1_000.0), 0, strategy);
+        let highs = [90.0, 100.0, 90.0, 100.0, 90.0, 100.0, 90.0];
+        let mut last_step = None;
+
+        for (index, high) in highs.into_iter().enumerate() {
+            last_step = Some(
+                runtime
+                    .on_market_input(MarketInput::CompletedCandle(candle_ohlc_at(
+                        90.0,
+                        high,
+                        80.0,
+                        90.0,
+                        index as i64,
+                        Timeframe::minutes(1),
+                    )))
+                    .expect("completed primary candle should be accepted"),
+            );
+        }
+
+        let final_step = last_step.expect("test should feed candles");
+        assert_eq!(
+            produced_decision(&final_step),
+            StrategyDecision::open_long(1.0)
+        );
+    }
+
+    #[test]
+    fn context_does_not_expose_anchored_compatibility_alias() {
+        let source = source_returning(
+            r#"
+let forbidden = context.anchored("trend");
+decision::hold()
+"#,
+        );
+
+        let step = run_completed_tick(&source);
+        let message = strategy_error_message(&step);
+
+        assert!(
+            message.contains("Function not found") || message.contains("function"),
+            "{message}"
+        );
+        assert!(!step
+            .events
+            .iter()
+            .any(|event| matches!(event, RuntimeEvent::StrategyDecisionProduced { .. })));
     }
 
     #[test]

--- a/trading-runtime/src/rhai_strategy.rs
+++ b/trading-runtime/src/rhai_strategy.rs
@@ -2,8 +2,10 @@
 //!
 //! This module owns compile/load-time Rhai strategy handling inside the
 //! `trading-runtime` crate, the typed decision API, grouped Strategy Context /
-//! Strategy State, and the Primary-Timeframe Market View used at the strategy
-//! tick boundary. Secondary Market View access is implemented in a later slice.
+//! Strategy State, and the typed Primary/Secondary-Timeframe Market View used
+//! at the strategy tick boundary. Optional Secondary-Timeframe `candle(tf)` and
+//! `candles(tf)` access returns Rhai unit `()` when that context is missing or
+//! stale for the current Strategy Tick.
 
 use crate::{
     RuntimePortfolioSnapshot, SecondaryTimeframeConfig, StrategyConfiguration, StrategyDecision,
@@ -13,7 +15,7 @@ use crate::{
 use indicators::trend::sma::sma;
 use rhai::{Dynamic, Engine as RhaiEngine, EvalAltResult, Module, Scope, AST, FLOAT, INT};
 use shared::{Candle, Position, Timeframe};
-use std::{error::Error, fmt, path::Path, sync::Arc};
+use std::{collections::HashMap, error::Error, fmt, path::Path, sync::Arc};
 
 /// Placeholder typed anchored configuration returned by `anchored_config()`.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -47,13 +49,49 @@ pub struct RhaiStrategy {
 struct RhaiMarketView {
     current: RhaiCandle,
     primary_history: RhaiCandleHistory,
+    histories_by_timeframe: HashMap<Timeframe, Option<RhaiCandleHistory>>,
 }
 
 impl RhaiMarketView {
     fn from_runtime(market: &crate::MarketView<'_>) -> Self {
-        Self {
+        let primary_history = RhaiCandleHistory::new(market.primary_history().to_vec());
+        let mut view = Self {
             current: RhaiCandle::new(market.primary_candle().clone()),
-            primary_history: RhaiCandleHistory::new(market.primary_history().to_vec()),
+            primary_history: primary_history.clone(),
+            histories_by_timeframe: HashMap::from([(
+                market.primary_timeframe(),
+                Some(primary_history),
+            )]),
+        };
+
+        for timeframe in market.configured_timeframes() {
+            if timeframe == market.primary_timeframe() {
+                continue;
+            }
+
+            let history = market
+                .visible_history(timeframe)
+                .expect("configured timeframe should be visible or unavailable");
+            view.insert_visible_history(timeframe, history);
+        }
+
+        view
+    }
+
+    fn insert_visible_history(&mut self, timeframe: Timeframe, history: Option<&[Candle]>) {
+        self.histories_by_timeframe.insert(
+            timeframe,
+            history.map(|candles| RhaiCandleHistory::new(candles.to_vec())),
+        );
+    }
+
+    fn visible_history(
+        &self,
+        timeframe: Timeframe,
+    ) -> Result<Option<RhaiCandleHistory>, Box<EvalAltResult>> {
+        match self.histories_by_timeframe.get(&timeframe) {
+            Some(history) => Ok(history.clone()),
+            None => Err(format!("unconfigured timeframe `{timeframe}`").into()),
         }
     }
 }
@@ -79,6 +117,10 @@ impl RhaiCandleHistory {
         Self {
             candles: Arc::new(candles),
         }
+    }
+
+    fn latest_candle(&self) -> Option<RhaiCandle> {
+        self.candles.last().cloned().map(RhaiCandle::new)
     }
 
     fn chronological_candles_before_offset(&self, offset: usize) -> &[Candle] {
@@ -575,9 +617,32 @@ fn register_market_view_api(engine: &mut RhaiEngine) {
     engine.register_fn("candle", |market: &mut RhaiMarketView| {
         market.current.clone()
     });
+    engine.register_fn(
+        "candle",
+        |market: &mut RhaiMarketView,
+         timeframe: Timeframe|
+         -> Result<Dynamic, Box<EvalAltResult>> {
+            Ok(market
+                .visible_history(timeframe)?
+                .and_then(|history| history.latest_candle())
+                .map(Dynamic::from)
+                .unwrap_or(Dynamic::UNIT))
+        },
+    );
     engine.register_fn("candles", |market: &mut RhaiMarketView| {
         market.primary_history.clone()
     });
+    engine.register_fn(
+        "candles",
+        |market: &mut RhaiMarketView,
+         timeframe: Timeframe|
+         -> Result<Dynamic, Box<EvalAltResult>> {
+            Ok(market
+                .visible_history(timeframe)?
+                .map(Dynamic::from)
+                .unwrap_or(Dynamic::UNIT))
+        },
+    );
 
     engine.register_get("open", |candle: &mut RhaiCandle| candle.candle.open);
     engine.register_get("high", |candle: &mut RhaiCandle| candle.candle.high);
@@ -897,15 +962,19 @@ fn on_tick(market, context) {
 "#;
 
     fn candle(close: f64) -> Candle {
+        candle_at(close, 1, Timeframe::minutes(1))
+    }
+
+    fn candle_at(close: f64, timestamp: i64, timeframe: Timeframe) -> Candle {
         Candle {
-            timestamp: 1,
+            timestamp,
             symbol: "BTC-USD".into(),
             open: close,
             high: close,
             low: close,
             close,
             volume: 1_000.0,
-            timeframe: Timeframe::minutes(1),
+            timeframe,
         }
     }
 
@@ -1207,6 +1276,249 @@ if previous != () && previous.close == 99.0 {
             produced_decision(&first_strategy_tick),
             StrategyDecision::open_long(1.0)
         );
+    }
+
+    #[test]
+    fn market_view_reads_available_secondary_candle_and_history_by_typed_timeframe() {
+        let source = r#"
+const H1 = timeframe("1h");
+
+fn on_tick(market, context) {
+    let h1 = market.candle(H1);
+    let h1_history = market.candles(H1);
+
+    if h1 != ()
+            && h1_history[1] != ()
+            && h1_history[2] != ()
+            && h1.close == 200.0
+            && h1_history[1].close == 200.0
+            && h1_history[2].close == 150.0 {
+        decision::open_long(1.0)
+    } else {
+        decision::hold()
+    }
+}
+"#;
+        let strategy = RhaiStrategy::load(&source).expect("strategy should load");
+        let mut runtime = TradingRuntime::with_config(
+            RuntimeConfig::with_secondary_configs(
+                "BTC-USD",
+                Timeframe::minutes(1),
+                [SecondaryTimeframeConfig::required(Timeframe::hours(1), 0)],
+            ),
+            PortfolioState::new(1_000.0),
+            0,
+            strategy,
+        );
+
+        runtime
+            .on_market_input(MarketInput::CompletedCandle(candle_at(
+                150.0,
+                0,
+                Timeframe::hours(1),
+            )))
+            .expect("first secondary candle should be accepted");
+        runtime
+            .on_market_input(MarketInput::CompletedCandle(candle_at(
+                200.0,
+                3_600_000,
+                Timeframe::hours(1),
+            )))
+            .expect("second secondary candle should be accepted");
+        let step = runtime
+            .on_market_input(MarketInput::CompletedCandle(candle_at(
+                100.0,
+                3_600_000,
+                Timeframe::minutes(1),
+            )))
+            .expect("primary candle should be accepted");
+
+        assert_eq!(produced_decision(&step), StrategyDecision::open_long(1.0));
+    }
+
+    #[test]
+    fn optional_secondary_missing_returns_unit_for_candle_and_candles() {
+        let source = source_returning(
+            r#"
+let H1 = timeframe("1h");
+if market.candle(H1) == () && market.candles(H1) == () {
+    decision::open_long(1.0)
+} else {
+    decision::hold()
+}
+"#,
+        );
+        let strategy = RhaiStrategy::load(&source).expect("strategy should load");
+        let mut runtime = TradingRuntime::with_config(
+            RuntimeConfig::with_secondary_configs(
+                "BTC-USD",
+                Timeframe::minutes(1),
+                [SecondaryTimeframeConfig::optional(Timeframe::hours(1), 0)],
+            ),
+            PortfolioState::new(1_000.0),
+            0,
+            strategy,
+        );
+
+        let step = runtime
+            .on_market_input(MarketInput::CompletedCandle(candle_at(
+                100.0,
+                60_000,
+                Timeframe::minutes(1),
+            )))
+            .expect("primary candle should be accepted");
+
+        assert_eq!(produced_decision(&step), StrategyDecision::open_long(1.0));
+    }
+
+    #[test]
+    fn optional_secondary_stale_returns_unit_for_candle_and_candles() {
+        let source = source_returning(
+            r#"
+let H1 = timeframe("1h");
+if market.candle(H1) == () && market.candles(H1) == () {
+    decision::open_long(1.0)
+} else {
+    decision::hold()
+}
+"#,
+        );
+        let strategy = RhaiStrategy::load(&source).expect("strategy should load");
+        let mut runtime = TradingRuntime::with_config(
+            RuntimeConfig::with_secondary_configs(
+                "BTC-USD",
+                Timeframe::minutes(1),
+                [SecondaryTimeframeConfig::optional(Timeframe::hours(1), 0)],
+            ),
+            PortfolioState::new(1_000.0),
+            0,
+            strategy,
+        );
+
+        runtime
+            .on_market_input(MarketInput::CompletedCandle(candle_at(
+                150.0,
+                0,
+                Timeframe::hours(1),
+            )))
+            .expect("secondary candle should be accepted");
+        let step = runtime
+            .on_market_input(MarketInput::CompletedCandle(candle_at(
+                100.0,
+                3_600_001,
+                Timeframe::minutes(1),
+            )))
+            .expect("primary candle should be accepted");
+
+        assert_eq!(produced_decision(&step), StrategyDecision::open_long(1.0));
+    }
+
+    #[test]
+    fn required_secondary_missing_blocks_before_rhai_on_tick() {
+        let source = source_returning("decision::open_long(1.0)");
+        let strategy = RhaiStrategy::load(&source).expect("strategy should load");
+        let mut runtime = TradingRuntime::with_config(
+            RuntimeConfig::with_secondary_configs(
+                "BTC-USD",
+                Timeframe::minutes(1),
+                [SecondaryTimeframeConfig::required(Timeframe::hours(1), 0)],
+            ),
+            PortfolioState::new(1_000.0),
+            0,
+            strategy,
+        );
+
+        let primary = candle_at(100.0, 60_000, Timeframe::minutes(1));
+        let step = runtime
+            .on_market_input(MarketInput::CompletedCandle(primary.clone()))
+            .expect("primary candle should be accepted");
+
+        assert!(step.events.contains(&RuntimeEvent::StrategyTickBlocked {
+            candle: primary,
+            blocked_contexts: vec![crate::BlockedSecondaryContext {
+                timeframe: Timeframe::hours(1),
+                reason: crate::SecondaryContextUnavailableReason::Missing,
+            }],
+        }));
+        assert!(!step.events.iter().any(|event| matches!(
+            event,
+            RuntimeEvent::StrategyTickStarted { .. }
+                | RuntimeEvent::StrategyDecisionProduced { .. }
+                | RuntimeEvent::PositionOpened { .. }
+        )));
+    }
+
+    #[test]
+    fn unconfigured_typed_timeframe_access_is_strategy_error_without_portfolio_transition() {
+        for access in ["market.candle(H4)", "market.candles(H4)"] {
+            let source = source_returning(&format!(
+                r#"
+let H4 = timeframe("4h");
+let ignored = {access};
+decision::open_long(1.0)
+"#
+            ));
+            let step = run_completed_tick(&source);
+            let message = strategy_error_message(&step);
+
+            assert!(message.contains("unconfigured timeframe `4h`"), "{message}");
+            assert!(!step.events.iter().any(|event| matches!(
+                event,
+                RuntimeEvent::StrategyDecisionProduced { .. }
+                    | RuntimeEvent::ExecutionActionPlanned { .. }
+                    | RuntimeEvent::PositionOpened { .. }
+            )));
+        }
+    }
+
+    #[test]
+    fn indicators_work_over_secondary_history() {
+        let source = source_returning(
+            r#"
+let H1 = timeframe("1h");
+let average = indicators::sma(market.candles(H1), 2);
+if average != () && average == 175.0 {
+    decision::open_long(1.0)
+} else {
+    decision::hold()
+}
+"#,
+        );
+        let strategy = RhaiStrategy::load(&source).expect("strategy should load");
+        let mut runtime = TradingRuntime::with_config(
+            RuntimeConfig::with_secondary_configs(
+                "BTC-USD",
+                Timeframe::minutes(1),
+                [SecondaryTimeframeConfig::required(Timeframe::hours(1), 0)],
+            ),
+            PortfolioState::new(1_000.0),
+            0,
+            strategy,
+        );
+
+        runtime
+            .on_market_input(MarketInput::CompletedCandle(candle_at(
+                150.0,
+                0,
+                Timeframe::hours(1),
+            )))
+            .expect("first secondary candle should be accepted");
+        runtime
+            .on_market_input(MarketInput::CompletedCandle(candle_at(
+                200.0,
+                3_600_000,
+                Timeframe::hours(1),
+            )))
+            .expect("second secondary candle should be accepted");
+        let step = runtime
+            .on_market_input(MarketInput::CompletedCandle(candle_at(
+                100.0,
+                3_600_000,
+                Timeframe::minutes(1),
+            )))
+            .expect("primary candle should be accepted");
+
+        assert_eq!(produced_decision(&step), StrategyDecision::open_long(1.0));
     }
 
     #[test]

--- a/trading-runtime/src/rhai_strategy.rs
+++ b/trading-runtime/src/rhai_strategy.rs
@@ -1,11 +1,14 @@
 //! Rhai strategy loading and hook validation for the trading runtime.
 //!
 //! This module owns compile/load-time Rhai strategy handling inside the
-//! `trading-runtime` crate. Tick execution and the full strategy-facing typed
-//! APIs are implemented in later Strategy Handling slices.
+//! `trading-runtime` crate and the typed decision API used at the strategy tick
+//! boundary. Full strategy-facing Market View and Context APIs are implemented
+//! in later Strategy Handling slices.
 
-use crate::StrategyDecision;
-use rhai::{Dynamic, Engine as RhaiEngine, EvalAltResult, Module, Scope, AST, INT};
+use crate::{
+    StrategyDecision, StrategyError, StrategyHandler, StrategyTickInput, StrategyTickResult,
+};
+use rhai::{Dynamic, Engine as RhaiEngine, EvalAltResult, Module, Scope, AST, FLOAT, INT};
 use shared::Timeframe;
 use std::{error::Error, fmt, path::Path, sync::Arc};
 
@@ -56,6 +59,31 @@ pub struct RhaiStrategy {
     hooks: RhaiStrategyHooks,
     strategy_config: StrategyConfiguration,
     anchored_config: Option<AnchoredConfiguration>,
+}
+
+impl StrategyHandler for RhaiStrategy {
+    fn on_tick(&mut self, _input: StrategyTickInput<'_>) -> StrategyTickResult {
+        let result =
+            match self
+                .engine
+                .call_fn::<Dynamic>(&mut self.scope, &self.ast, ON_TICK_HOOK, ((), ()))
+            {
+                Ok(result) => result,
+                Err(error) => {
+                    return StrategyTickResult::Error(StrategyError::new(format!(
+                        "strategy hook `on_tick` failed: {error}"
+                    )))
+                }
+            };
+
+        let actual_type = result.type_name().to_string();
+        match result.try_cast::<StrategyDecision>() {
+            Some(decision) => StrategyTickResult::Decision(decision),
+            None => StrategyTickResult::Error(StrategyError::new(format!(
+                "strategy hook `on_tick` must return typed StrategyDecision from `decision::*`; got {actual_type}"
+            ))),
+        }
+    }
 }
 
 impl RhaiStrategy {
@@ -244,11 +272,27 @@ fn new_rhai_engine() -> RhaiEngine {
     anchored_config_module.set_native_fn("new", || Ok(AnchoredConfiguration::new()));
     engine.register_static_module("anchored_config", Arc::new(anchored_config_module));
 
-    // Minimal placeholder for loader smoke tests. Full typed decision execution
-    // is intentionally left to the Strategy Decision Rhai API issue.
     let mut decision_module = Module::new();
     decision_module.set_native_fn("hold", || Ok(StrategyDecision::hold()));
+    decision_module.set_native_fn("open_long", |quantity: FLOAT| {
+        Ok(StrategyDecision::open_long(quantity))
+    });
+    decision_module.set_native_fn("open_long", |quantity: INT| {
+        Ok(StrategyDecision::open_long(quantity as f64))
+    });
+    decision_module.set_native_fn("close_long", || Ok(StrategyDecision::close_long()));
+    decision_module.set_native_fn("open_short", |quantity: FLOAT| {
+        Ok(StrategyDecision::open_short(quantity))
+    });
+    decision_module.set_native_fn("open_short", |quantity: INT| {
+        Ok(StrategyDecision::open_short(quantity as f64))
+    });
+    decision_module.set_native_fn("close_short", || Ok(StrategyDecision::close_short()));
     engine.register_static_module("decision", Arc::new(decision_module));
+
+    engine.register_fn("with_stop_loss", with_stop_loss);
+    engine.register_fn("with_take_profit", with_take_profit);
+    engine.register_fn("with_reason", with_reason);
 
     engine
 }
@@ -365,6 +409,45 @@ fn with_minimum_warmup(
     Ok(config.with_minimum_warmup(minimum_warmup))
 }
 
+fn with_stop_loss(
+    decision: StrategyDecision,
+    stop_loss: FLOAT,
+) -> Result<StrategyDecision, Box<EvalAltResult>> {
+    ensure_opening_decision(&decision, "with_stop_loss")?;
+    let take_profit = decision.take_profit;
+
+    Ok(decision.with_entry_risk(Some(stop_loss), take_profit))
+}
+
+fn with_take_profit(
+    decision: StrategyDecision,
+    take_profit: FLOAT,
+) -> Result<StrategyDecision, Box<EvalAltResult>> {
+    ensure_opening_decision(&decision, "with_take_profit")?;
+    let stop_loss = decision.stop_loss;
+
+    Ok(decision.with_entry_risk(stop_loss, Some(take_profit)))
+}
+
+fn with_reason(decision: StrategyDecision, reason: &str) -> StrategyDecision {
+    decision.with_reason(reason)
+}
+
+fn ensure_opening_decision(
+    decision: &StrategyDecision,
+    method: &'static str,
+) -> Result<(), Box<EvalAltResult>> {
+    if decision.intent.opens_position() {
+        Ok(())
+    } else {
+        Err(format!(
+            "`{method}` is only valid on opening decisions; got {:?}",
+            decision.intent
+        )
+        .into())
+    }
+}
+
 fn validate_required_on_tick(ast: &AST) -> Result<(), RhaiStrategyLoadError> {
     if has_hook_with_arity(ast, ON_TICK_HOOK, 2) {
         return Ok(());
@@ -458,12 +541,59 @@ fn has_hook_with_arity(ast: &AST, name: &str, arity: usize) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        ExecutionAction, IgnoredDecisionReason, MarketInput, PortfolioState, RuntimeEvent,
+        StrategyDecisionIntent, TradingRuntime,
+    };
+    use shared::{Candle, Timeframe};
 
     const MINIMAL: &str = r#"
 fn on_tick(market, context) {
     decision::hold()
 }
 "#;
+
+    fn candle(close: f64) -> Candle {
+        Candle {
+            timestamp: 1,
+            symbol: "BTC-USD".into(),
+            open: close,
+            high: close,
+            low: close,
+            close,
+            volume: 1_000.0,
+            timeframe: Timeframe::minutes(1),
+        }
+    }
+
+    fn source_returning(expression: &str) -> String {
+        format!(
+            r#"
+fn on_tick(market, context) {{
+    {expression}
+}}
+"#
+        )
+    }
+
+    fn run_completed_tick(source: &str) -> crate::RuntimeStep {
+        let strategy = RhaiStrategy::load(source).expect("strategy should load");
+        let mut runtime = TradingRuntime::new(PortfolioState::new(1_000.0), 0, strategy);
+
+        runtime
+            .on_market_input(MarketInput::CompletedCandle(candle(100.0)))
+            .expect("completed primary candle should be accepted")
+    }
+
+    fn produced_decision(step: &crate::RuntimeStep) -> StrategyDecision {
+        step.events
+            .iter()
+            .find_map(|event| match event {
+                RuntimeEvent::StrategyDecisionProduced { decision } => Some(decision.clone()),
+                _ => None,
+            })
+            .expect("step should include a produced strategy decision")
+    }
 
     #[test]
     fn loads_minimal_strategy_with_only_on_tick() {
@@ -503,6 +633,187 @@ fn on_tick(market, context) {
 
         assert!(strategy.hooks().has_strategy_config);
         assert_eq!(strategy.strategy_config().minimum_warmup(), 200);
+    }
+
+    #[test]
+    fn typed_decision_constructors_return_runtime_decisions() {
+        let cases = [
+            ("decision::hold()", StrategyDecision::hold()),
+            ("decision::open_long(2.0)", StrategyDecision::open_long(2.0)),
+            ("decision::close_long()", StrategyDecision::close_long()),
+            (
+                "decision::open_short(3.0)",
+                StrategyDecision::open_short(3.0),
+            ),
+            ("decision::close_short()", StrategyDecision::close_short()),
+        ];
+
+        for (expression, expected_decision) in cases {
+            let source = source_returning(expression);
+            let step = run_completed_tick(&source);
+
+            assert_eq!(produced_decision(&step), expected_decision, "{expression}");
+        }
+    }
+
+    #[test]
+    fn fluent_open_long_risk_and_reason_map_to_runtime_decision_fields() {
+        let source = source_returning(
+            r#"decision::open_long(2.0)
+                .with_stop_loss(95.0)
+                .with_take_profit(120.0)
+                .with_reason("breakout")"#,
+        );
+
+        let step = run_completed_tick(&source);
+        let decision = produced_decision(&step);
+
+        assert_eq!(decision.intent, StrategyDecisionIntent::OpenLong);
+        assert_eq!(decision.quantity, Some(2.0));
+        assert_eq!(decision.stop_loss, Some(95.0));
+        assert_eq!(decision.take_profit, Some(120.0));
+        assert_eq!(decision.reason.as_deref(), Some("breakout"));
+        assert!(step.events.iter().any(|event| match event {
+            RuntimeEvent::ExecutionActionPlanned { action } => {
+                action
+                    == &(ExecutionAction::OpenLong {
+                        quantity: 2.0,
+                        stop_loss: Some(95.0),
+                        take_profit: Some(120.0),
+                    })
+            }
+            _ => false,
+        }));
+    }
+
+    #[test]
+    fn fluent_open_short_risk_maps_to_runtime_decision_fields() {
+        let source = source_returning(
+            r#"decision::open_short(4.0)
+                .with_stop_loss(105.0)
+                .with_take_profit(80.0)"#,
+        );
+
+        let step = run_completed_tick(&source);
+        let decision = produced_decision(&step);
+
+        assert_eq!(decision.intent, StrategyDecisionIntent::OpenShort);
+        assert_eq!(decision.quantity, Some(4.0));
+        assert_eq!(decision.stop_loss, Some(105.0));
+        assert_eq!(decision.take_profit, Some(80.0));
+        assert!(step.events.iter().any(|event| match event {
+            RuntimeEvent::ExecutionActionPlanned { action } => {
+                action
+                    == &(ExecutionAction::OpenShort {
+                        quantity: 4.0,
+                        stop_loss: Some(105.0),
+                        take_profit: Some(80.0),
+                    })
+            }
+            _ => false,
+        }));
+    }
+
+    #[test]
+    fn reason_is_diagnostic_only_and_allowed_on_non_opening_decisions() {
+        let cases = [
+            (
+                "decision::hold().with_reason(\"waiting\")",
+                StrategyDecisionIntent::Hold,
+            ),
+            (
+                "decision::close_long().with_reason(\"target reached\")",
+                StrategyDecisionIntent::CloseLong,
+            ),
+            (
+                "decision::close_short().with_reason(\"covered\")",
+                StrategyDecisionIntent::CloseShort,
+            ),
+        ];
+
+        for (expression, expected_intent) in cases {
+            let source = source_returning(expression);
+            let step = run_completed_tick(&source);
+            let decision = produced_decision(&step);
+
+            assert_eq!(decision.intent, expected_intent, "{expression}");
+            assert!(decision.reason.is_some(), "{expression}");
+        }
+    }
+
+    #[test]
+    fn risk_methods_on_non_opening_decisions_are_strategy_errors_without_execution_planning() {
+        for expression in [
+            "decision::hold().with_stop_loss(95.0)",
+            "decision::close_long().with_take_profit(120.0)",
+        ] {
+            let source = source_returning(expression);
+            let step = run_completed_tick(&source);
+
+            assert!(step.events.iter().any(|event| matches!(
+                event,
+                RuntimeEvent::StrategyError { error, .. }
+                    if error.message.contains("only valid on opening decisions")
+            )));
+            assert!(!step.events.iter().any(|event| matches!(
+                event,
+                RuntimeEvent::StrategyDecisionProduced { .. }
+                    | RuntimeEvent::ExecutionActionPlanned { .. }
+            )));
+        }
+    }
+
+    #[test]
+    fn wrong_on_tick_return_types_are_strategy_errors_without_legacy_mapping_or_planning() {
+        for expression in [
+            r#"#{ signal: "BUY", size: 0.5 }"#,
+            r#"#{ intent: "OPEN_LONG", quantity: 2.0 }"#,
+            r#""HOLD""#,
+            "()",
+            "42.0",
+        ] {
+            let source = source_returning(expression);
+            let step = run_completed_tick(&source);
+
+            assert!(
+                step.events.iter().any(|event| matches!(
+                    event,
+                    RuntimeEvent::StrategyError { error, .. }
+                        if error.message.contains("must return typed StrategyDecision")
+                )),
+                "{expression}"
+            );
+            assert!(
+                !step.events.iter().any(|event| matches!(
+                    event,
+                    RuntimeEvent::StrategyDecisionProduced { .. }
+                        | RuntimeEvent::ExecutionActionPlanned { .. }
+                )),
+                "{expression}"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_opening_quantity_uses_existing_runtime_ignored_decision_semantics() {
+        let source = source_returning("decision::open_long(0.0)");
+
+        let step = run_completed_tick(&source);
+
+        assert_eq!(produced_decision(&step), StrategyDecision::open_long(0.0));
+        assert!(step.events.iter().any(|event| matches!(
+            event,
+            RuntimeEvent::ExecutionActionPlanned {
+                action: ExecutionAction::Noop,
+            }
+        )));
+        assert!(step.events.iter().any(|event| matches!(
+            event,
+            RuntimeEvent::StrategyDecisionIgnored {
+                reason: IgnoredDecisionReason::InvalidQuantity,
+                ..
+            }
+        )));
     }
 
     #[test]

--- a/trading-runtime/src/runtime.rs
+++ b/trading-runtime/src/runtime.rs
@@ -6,7 +6,7 @@ use crate::{
     ForceCloseIgnoredReason, MarketInput, MarketState, MarketView, PortfolioState, RuntimeConfig,
     RuntimeEvent, RuntimeInputError, RuntimeStep, SecondaryContextUnavailableReason,
     SecondaryReadiness, SecondaryTimeframeConfig, StrategyContext, StrategyHandler, StrategyState,
-    StrategyTickInput, StrategyTickResult,
+    StrategyTickInput, StrategyTickResult, WarmupPlan,
 };
 use shared::{Candle, PositionSide, Timeframe};
 use std::collections::HashMap;
@@ -18,7 +18,7 @@ pub struct TradingRuntime<S> {
     market_state: MarketState,
     portfolio: PortfolioState,
     warmup_progress: HashMap<Timeframe, usize>,
-    warmup_requirement: usize,
+    warmup_plan: WarmupPlan,
     warmup_completed: bool,
     strategy_state: StrategyState,
     strategy_handler: S,
@@ -40,20 +40,34 @@ impl<S: StrategyHandler> TradingRuntime<S> {
         warmup_requirement: usize,
         strategy_handler: S,
     ) -> Self {
+        let warmup_plan = WarmupPlan::same_requirement(&config, warmup_requirement);
+        Self::with_warmup_plan(config, portfolio, warmup_plan, strategy_handler)
+    }
+
+    pub fn with_warmup_plan(
+        config: RuntimeConfig,
+        portfolio: PortfolioState,
+        warmup_plan: WarmupPlan,
+        strategy_handler: S,
+    ) -> Self {
         let market_state = MarketState::from_config(&config);
         let warmup_progress = config
             .configured_timeframes()
             .into_iter()
             .map(|timeframe| (timeframe, 0))
             .collect();
+        let warmup_completed = config
+            .configured_timeframes()
+            .iter()
+            .all(|timeframe| warmup_plan.requirement_for(*timeframe).unwrap_or(0) == 0);
 
         Self {
             config,
             market_state,
             portfolio,
             warmup_progress,
-            warmup_requirement,
-            warmup_completed: warmup_requirement == 0,
+            warmup_plan,
+            warmup_completed,
             strategy_state: StrategyState::default(),
             strategy_handler,
         }
@@ -119,14 +133,14 @@ impl<S: StrategyHandler> TradingRuntime<S> {
         events.push(RuntimeEvent::WarmupAdvanced {
             timeframe,
             current_warmup_input_count,
-            required_warmup_inputs: self.warmup_requirement,
+            required_warmup_inputs: self.required_warmup_inputs(timeframe),
         });
 
         if !self.warmup_completed && self.is_warmup_complete() {
             self.warmup_completed = true;
             events.push(RuntimeEvent::WarmupCompleted {
                 completed_timeframes: self.config.configured_timeframes(),
-                required_warmup_inputs: self.warmup_requirement,
+                required_warmup_inputs: self.warmup_requirement(),
             });
         }
 
@@ -370,7 +384,15 @@ impl<S: StrategyHandler> TradingRuntime<S> {
     }
 
     pub fn warmup_requirement(&self) -> usize {
-        self.warmup_requirement
+        self.warmup_plan.effective_requirement()
+    }
+
+    pub fn warmup_plan(&self) -> &WarmupPlan {
+        &self.warmup_plan
+    }
+
+    fn required_warmup_inputs(&self, timeframe: Timeframe) -> usize {
+        self.warmup_plan.requirement_for(timeframe).unwrap_or(0)
     }
 
     fn advance_warmup_progress(&mut self, timeframe: Timeframe) -> usize {
@@ -380,10 +402,10 @@ impl<S: StrategyHandler> TradingRuntime<S> {
     }
 
     fn is_warmup_complete(&self) -> bool {
-        self.warmup_requirement == 0
-            || self.config.configured_timeframes().iter().all(|timeframe| {
-                self.warmup_progress.get(timeframe).copied().unwrap_or(0) >= self.warmup_requirement
-            })
+        self.config.configured_timeframes().iter().all(|timeframe| {
+            self.warmup_progress.get(timeframe).copied().unwrap_or(0)
+                >= self.required_warmup_inputs(*timeframe)
+        })
     }
 
     fn evaluate_secondary_readiness(

--- a/trading-runtime/src/runtime.rs
+++ b/trading-runtime/src/runtime.rs
@@ -3,9 +3,10 @@
 use crate::market_input::MarketInputTimeframeRole;
 use crate::{
     evaluate_risk_exit, plan_execution, BlockedSecondaryContext, ExecutionAction, ExitKind,
-    ForceCloseIgnoredReason, MarketInput, MarketState, PortfolioState, RuntimeConfig, RuntimeEvent,
-    RuntimeInputError, RuntimeStep, SecondaryContextUnavailableReason, SecondaryReadiness,
-    SecondaryTimeframeConfig, StrategyHandler,
+    ForceCloseIgnoredReason, MarketInput, MarketState, MarketView, PortfolioState, RuntimeConfig,
+    RuntimeEvent, RuntimeInputError, RuntimeStep, SecondaryContextUnavailableReason,
+    SecondaryReadiness, SecondaryTimeframeConfig, StrategyContext, StrategyHandler, StrategyState,
+    StrategyTickInput, StrategyTickResult,
 };
 use shared::{Candle, PositionSide, Timeframe};
 use std::collections::HashMap;
@@ -19,6 +20,7 @@ pub struct TradingRuntime<S> {
     warmup_progress: HashMap<Timeframe, usize>,
     warmup_requirement: usize,
     warmup_completed: bool,
+    strategy_state: StrategyState,
     strategy_handler: S,
 }
 
@@ -52,6 +54,7 @@ impl<S: StrategyHandler> TradingRuntime<S> {
             warmup_progress,
             warmup_requirement,
             warmup_completed: warmup_requirement == 0,
+            strategy_state: StrategyState::default(),
             strategy_handler,
         }
     }
@@ -198,9 +201,27 @@ impl<S: StrategyHandler> TradingRuntime<S> {
         });
 
         let portfolio_before_decision = self.portfolio.snapshot(candle.close);
-        let decision = self
-            .strategy_handler
-            .next_decision(&candle, &portfolio_before_decision);
+        let tick_input = StrategyTickInput {
+            market: MarketView::new(&self.market_state, self.config.primary_timeframe, &candle),
+            context: StrategyContext {
+                portfolio: &portfolio_before_decision,
+                state: &mut self.strategy_state,
+            },
+            primary_candle: &candle,
+        };
+        let decision = match self.strategy_handler.on_tick(tick_input) {
+            StrategyTickResult::Decision(decision) => decision,
+            StrategyTickResult::Error(error) => {
+                events.push(RuntimeEvent::StrategyError {
+                    candle: candle.clone(),
+                    error,
+                });
+                events.push(RuntimeEvent::StrategyTickCompleted);
+                events.push(RuntimeEvent::TradableCandleCompleted);
+
+                return RuntimeStep::new(events, self.portfolio.snapshot(candle.close));
+            }
+        };
         events.push(RuntimeEvent::StrategyDecisionProduced {
             decision: decision.clone(),
         });

--- a/trading-runtime/src/runtime.rs
+++ b/trading-runtime/src/runtime.rs
@@ -202,7 +202,12 @@ impl<S: StrategyHandler> TradingRuntime<S> {
 
         let portfolio_before_decision = self.portfolio.snapshot(candle.close);
         let tick_input = StrategyTickInput {
-            market: MarketView::new(&self.market_state, self.config.primary_timeframe, &candle),
+            market: MarketView::new(
+                &self.market_state,
+                self.config.primary_timeframe,
+                self.config.secondary_configs(),
+                &candle,
+            ),
             context: StrategyContext {
                 portfolio: &portfolio_before_decision,
                 state: &mut self.strategy_state,

--- a/trading-runtime/src/runtime.rs
+++ b/trading-runtime/src/runtime.rs
@@ -101,6 +101,7 @@ impl<S: StrategyHandler> TradingRuntime<S> {
 
     fn on_completed_primary_before_warmup_complete(&mut self, candle: Candle) -> RuntimeStep {
         self.market_state.record_accepted_candle(candle.clone());
+        self.notify_strategy_market_input_accepted(&candle);
 
         RuntimeStep::new(
             vec![RuntimeEvent::MarketInputAccepted {
@@ -112,6 +113,7 @@ impl<S: StrategyHandler> TradingRuntime<S> {
 
     fn on_secondary_completed_candle(&mut self, candle: Candle) -> RuntimeStep {
         self.market_state.record_accepted_candle(candle.clone());
+        self.notify_strategy_market_input_accepted(&candle);
 
         RuntimeStep::new(
             vec![RuntimeEvent::MarketInputAccepted {
@@ -123,6 +125,7 @@ impl<S: StrategyHandler> TradingRuntime<S> {
 
     pub fn on_warmup_input(&mut self, candle: Candle) -> RuntimeStep {
         self.market_state.record_accepted_candle(candle.clone());
+        self.notify_strategy_market_input_accepted(&candle);
         let timeframe = candle.timeframe;
         let current_warmup_input_count = self.advance_warmup_progress(timeframe);
 
@@ -149,6 +152,7 @@ impl<S: StrategyHandler> TradingRuntime<S> {
 
     fn handle_completed_primary_after_warmup(&mut self, candle: Candle) -> RuntimeStep {
         self.market_state.record_accepted_candle(candle.clone());
+        self.notify_strategy_market_input_accepted(&candle);
 
         let mut events = vec![RuntimeEvent::MarketInputAccepted {
             candle: candle.clone(),
@@ -393,6 +397,14 @@ impl<S: StrategyHandler> TradingRuntime<S> {
 
     fn required_warmup_inputs(&self, timeframe: Timeframe) -> usize {
         self.warmup_plan.requirement_for(timeframe).unwrap_or(0)
+    }
+
+    fn notify_strategy_market_input_accepted(&mut self, candle: &Candle) {
+        self.strategy_handler.on_market_input_accepted(
+            &self.market_state,
+            candle,
+            self.config.primary_timeframe,
+        );
     }
 
     fn advance_warmup_progress(&mut self, timeframe: Timeframe) -> usize {

--- a/trading-runtime/src/strategy.rs
+++ b/trading-runtime/src/strategy.rs
@@ -2,7 +2,10 @@
 
 use crate::{MarketState, RuntimePortfolioSnapshot, StrategyDecision};
 use shared::{Candle, Timeframe};
-use std::collections::VecDeque;
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{Arc, RwLock},
+};
 
 /// Strategy-facing read-only view over runtime-owned Market State for one tick.
 #[derive(Debug, Clone, Copy)]
@@ -43,12 +46,61 @@ impl<'a> MarketView<'a> {
     }
 }
 
+/// Primitive value stored in session-local Strategy State.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StrategyStateValue {
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+    String(String),
+}
+
 /// Session-local Strategy State handle.
 ///
-/// This issue only establishes the typed boundary. Concrete state value APIs are
-/// intentionally left to later Strategy Context/State work.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct StrategyState;
+/// Strategy State is runtime-owned memory for one running strategy. Clones share
+/// the same underlying session-local storage so strategy-facing adapters can pass
+/// lightweight handles into script runtimes without losing mutations.
+#[derive(Debug, Clone, Default)]
+pub struct StrategyState {
+    values: Arc<RwLock<HashMap<String, StrategyStateValue>>>,
+}
+
+impl StrategyState {
+    pub fn get(&self, key: &str) -> Option<StrategyStateValue> {
+        self.values
+            .read()
+            .expect("strategy state lock should not be poisoned")
+            .get(key)
+            .cloned()
+    }
+
+    pub fn set(&self, key: impl Into<String>, value: StrategyStateValue) {
+        self.values
+            .write()
+            .expect("strategy state lock should not be poisoned")
+            .insert(key.into(), value);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.values
+            .read()
+            .expect("strategy state lock should not be poisoned")
+            .is_empty()
+    }
+}
+
+impl PartialEq for StrategyState {
+    fn eq(&self, other: &Self) -> bool {
+        *self
+            .values
+            .read()
+            .expect("strategy state lock should not be poisoned")
+            == *other
+                .values
+                .read()
+                .expect("strategy state lock should not be poisoned")
+    }
+}
 
 /// Grouped strategy-facing runtime context for one Strategy Tick.
 pub struct StrategyContext<'a> {

--- a/trading-runtime/src/strategy.rs
+++ b/trading-runtime/src/strategy.rs
@@ -1,6 +1,6 @@
 //! Strategy tick boundary abstractions for the trading runtime.
 
-use crate::{MarketState, RuntimePortfolioSnapshot, StrategyDecision};
+use crate::{MarketState, RuntimePortfolioSnapshot, SecondaryTimeframeConfig, StrategyDecision};
 use shared::{Candle, Timeframe};
 use std::{
     collections::{HashMap, VecDeque},
@@ -12,6 +12,7 @@ use std::{
 pub struct MarketView<'a> {
     market_state: &'a MarketState,
     primary_timeframe: Timeframe,
+    secondary_timeframes: &'a [SecondaryTimeframeConfig],
     primary_candle: &'a Candle,
 }
 
@@ -19,11 +20,13 @@ impl<'a> MarketView<'a> {
     pub(crate) fn new(
         market_state: &'a MarketState,
         primary_timeframe: Timeframe,
+        secondary_timeframes: &'a [SecondaryTimeframeConfig],
         primary_candle: &'a Candle,
     ) -> Self {
         Self {
             market_state,
             primary_timeframe,
+            secondary_timeframes,
             primary_candle,
         }
     }
@@ -38,11 +41,57 @@ impl<'a> MarketView<'a> {
         self.primary_candle
     }
 
+    /// All timeframes configured for this Market View.
+    pub fn configured_timeframes(&self) -> impl Iterator<Item = Timeframe> + '_ {
+        std::iter::once(self.primary_timeframe).chain(
+            self.secondary_timeframes
+                .iter()
+                .map(|secondary| secondary.timeframe),
+        )
+    }
+
     /// Chronological Primary Timeframe history visible to this Strategy Tick.
     pub fn primary_history(&self) -> &'a [Candle] {
         self.market_state
             .history(self.primary_timeframe)
             .expect("primary timeframe history should be configured")
+    }
+
+    /// Visible candle history for a configured timeframe.
+    ///
+    /// Primary history is always visible. Secondary history is visible only when
+    /// the configured Secondary context is currently available/fresh for this
+    /// Strategy Tick. Unavailable optional Secondary context returns `Ok(None)`;
+    /// unconfigured timeframe access returns a strategy-facing error.
+    pub fn visible_history(
+        &self,
+        timeframe: Timeframe,
+    ) -> Result<Option<&'a [Candle]>, MarketViewTimeframeError> {
+        if timeframe == self.primary_timeframe {
+            return Ok(Some(self.primary_history()));
+        }
+
+        let secondary = self
+            .secondary_timeframes
+            .iter()
+            .find(|secondary| secondary.timeframe == timeframe)
+            .ok_or(MarketViewTimeframeError::UnconfiguredTimeframe { timeframe })?;
+
+        if self.secondary_context_is_unavailable(secondary) {
+            Ok(None)
+        } else {
+            Ok(self.market_state.history(timeframe))
+        }
+    }
+
+    /// Latest candle currently visible for a configured timeframe.
+    pub fn visible_latest_candle(
+        &self,
+        timeframe: Timeframe,
+    ) -> Result<Option<&'a Candle>, MarketViewTimeframeError> {
+        Ok(self
+            .visible_history(timeframe)?
+            .and_then(|history| history.last()))
     }
 
     /// Latest candle currently held by Market State for a configured timeframe.
@@ -51,7 +100,38 @@ impl<'a> MarketView<'a> {
             .history(timeframe)
             .and_then(|history| history.last())
     }
+
+    fn secondary_context_is_unavailable(&self, secondary: &SecondaryTimeframeConfig) -> bool {
+        let Some(latest_secondary) = self.latest_candle(secondary.timeframe) else {
+            return true;
+        };
+
+        let duration_ms = secondary.timeframe.duration_ms();
+        let allowed_until = latest_secondary.timestamp.saturating_add(
+            duration_ms.saturating_mul(i64::from(secondary.max_missing_candles) + 1),
+        );
+
+        self.primary_candle.timestamp > allowed_until
+    }
 }
+
+/// Strategy-facing Market View timeframe access error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MarketViewTimeframeError {
+    UnconfiguredTimeframe { timeframe: Timeframe },
+}
+
+impl std::fmt::Display for MarketViewTimeframeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnconfiguredTimeframe { timeframe } => {
+                write!(formatter, "unconfigured timeframe `{timeframe}`")
+            }
+        }
+    }
+}
+
+impl std::error::Error for MarketViewTimeframeError {}
 
 /// Primitive value stored in session-local Strategy State.
 #[derive(Debug, Clone, PartialEq)]

--- a/trading-runtime/src/strategy.rs
+++ b/trading-runtime/src/strategy.rs
@@ -1,16 +1,98 @@
-//! Minimal strategy handler abstractions for runtime tests.
+//! Strategy tick boundary abstractions for the trading runtime.
 
-use crate::{RuntimePortfolioSnapshot, StrategyDecision};
-use shared::Candle;
+use crate::{MarketState, RuntimePortfolioSnapshot, StrategyDecision};
+use shared::{Candle, Timeframe};
 use std::collections::VecDeque;
 
-/// Strategy-decision source used by the runtime.
+/// Strategy-facing read-only view over runtime-owned Market State for one tick.
+#[derive(Debug, Clone, Copy)]
+pub struct MarketView<'a> {
+    market_state: &'a MarketState,
+    primary_timeframe: Timeframe,
+    primary_candle: &'a Candle,
+}
+
+impl<'a> MarketView<'a> {
+    pub(crate) fn new(
+        market_state: &'a MarketState,
+        primary_timeframe: Timeframe,
+        primary_candle: &'a Candle,
+    ) -> Self {
+        Self {
+            market_state,
+            primary_timeframe,
+            primary_candle,
+        }
+    }
+
+    /// Configured Primary Timeframe for this Strategy Tick.
+    pub fn primary_timeframe(&self) -> Timeframe {
+        self.primary_timeframe
+    }
+
+    /// The current Primary Strategy Tick candle.
+    pub fn primary_candle(&self) -> &'a Candle {
+        self.primary_candle
+    }
+
+    /// Latest candle currently held by Market State for a configured timeframe.
+    pub fn latest_candle(&self, timeframe: Timeframe) -> Option<&'a Candle> {
+        self.market_state
+            .history(timeframe)
+            .and_then(|history| history.last())
+    }
+}
+
+/// Session-local Strategy State handle.
+///
+/// This issue only establishes the typed boundary. Concrete state value APIs are
+/// intentionally left to later Strategy Context/State work.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StrategyState;
+
+/// Grouped strategy-facing runtime context for one Strategy Tick.
+pub struct StrategyContext<'a> {
+    pub portfolio: &'a RuntimePortfolioSnapshot,
+    pub state: &'a mut StrategyState,
+}
+
+/// Runtime-owned input passed to Strategy Handling for one Strategy Tick.
+pub struct StrategyTickInput<'a> {
+    pub market: MarketView<'a>,
+    pub context: StrategyContext<'a>,
+    pub primary_candle: &'a Candle,
+}
+
+/// Tick-time error returned by Strategy Handling.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StrategyError {
+    pub message: String,
+}
+
+impl StrategyError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+/// Result of evaluating a Strategy Tick.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StrategyTickResult {
+    Decision(StrategyDecision),
+    Error(StrategyError),
+}
+
+impl From<StrategyDecision> for StrategyTickResult {
+    fn from(decision: StrategyDecision) -> Self {
+        Self::Decision(decision)
+    }
+}
+
+/// Strategy Tick evaluator used by the runtime.
 pub trait StrategyHandler {
-    fn next_decision(
-        &mut self,
-        candle: &Candle,
-        portfolio: &RuntimePortfolioSnapshot,
-    ) -> StrategyDecision;
+    fn on_tick(&mut self, input: StrategyTickInput<'_>) -> StrategyTickResult;
 }
 
 /// Test-oriented strategy handler that returns predetermined decisions.
@@ -28,13 +110,11 @@ impl PredeterminedStrategyHandler {
 }
 
 impl StrategyHandler for PredeterminedStrategyHandler {
-    fn next_decision(
-        &mut self,
-        _candle: &Candle,
-        _portfolio: &RuntimePortfolioSnapshot,
-    ) -> StrategyDecision {
-        self.decisions
-            .pop_front()
-            .unwrap_or_else(StrategyDecision::hold)
+    fn on_tick(&mut self, _input: StrategyTickInput<'_>) -> StrategyTickResult {
+        StrategyTickResult::Decision(
+            self.decisions
+                .pop_front()
+                .unwrap_or_else(StrategyDecision::hold),
+        )
     }
 }

--- a/trading-runtime/src/strategy.rs
+++ b/trading-runtime/src/strategy.rs
@@ -231,6 +231,18 @@ impl From<StrategyDecision> for StrategyTickResult {
 
 /// Strategy Tick evaluator used by the runtime.
 pub trait StrategyHandler {
+    /// Notify Strategy Handling that market input has been accepted into Runtime Market State.
+    ///
+    /// Rhai-backed handlers use this to update runtime-owned Compute State such as
+    /// anchored/structure-aware outputs. Test handlers can keep the default no-op.
+    fn on_market_input_accepted(
+        &mut self,
+        _market_state: &MarketState,
+        _candle: &Candle,
+        _primary_timeframe: Timeframe,
+    ) {
+    }
+
     fn on_tick(&mut self, input: StrategyTickInput<'_>) -> StrategyTickResult;
 }
 

--- a/trading-runtime/src/strategy.rs
+++ b/trading-runtime/src/strategy.rs
@@ -38,6 +38,13 @@ impl<'a> MarketView<'a> {
         self.primary_candle
     }
 
+    /// Chronological Primary Timeframe history visible to this Strategy Tick.
+    pub fn primary_history(&self) -> &'a [Candle] {
+        self.market_state
+            .history(self.primary_timeframe)
+            .expect("primary timeframe history should be configured")
+    }
+
     /// Latest candle currently held by Market State for a configured timeframe.
     pub fn latest_candle(&self, timeframe: Timeframe) -> Option<&'a Candle> {
         self.market_state

--- a/trading-runtime/src/strategy_config.rs
+++ b/trading-runtime/src/strategy_config.rs
@@ -1,0 +1,38 @@
+//! Typed strategy-declared configuration for runtime strategy handling.
+
+use crate::market_input::SecondaryTimeframeConfig;
+
+/// Typed strategy-declared configuration returned by `strategy_config()`.
+///
+/// Strategy Configuration may declare only strategy requirements/defaults such as
+/// minimum warmup and Secondary-Timeframe requirements. Run Configuration remains
+/// authoritative for runtime asset, Primary Timeframe, and conflicts.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StrategyConfiguration {
+    minimum_warmup: usize,
+    secondary_timeframes: Vec<SecondaryTimeframeConfig>,
+}
+
+impl StrategyConfiguration {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn minimum_warmup(&self) -> usize {
+        self.minimum_warmup
+    }
+
+    pub fn secondary_timeframes(&self) -> &[SecondaryTimeframeConfig] {
+        &self.secondary_timeframes
+    }
+
+    pub(crate) fn with_minimum_warmup(mut self, minimum_warmup: usize) -> Self {
+        self.minimum_warmup = minimum_warmup;
+        self
+    }
+
+    pub(crate) fn with_secondary(mut self, secondary: SecondaryTimeframeConfig) -> Self {
+        self.secondary_timeframes.push(secondary);
+        self
+    }
+}

--- a/trading-runtime/src/warmup.rs
+++ b/trading-runtime/src/warmup.rs
@@ -1,0 +1,454 @@
+//! Warmup detection and planning for Trading Runtime strategy handling.
+
+use crate::{RuntimeConfig, StrategyConfiguration};
+use rhai::{Expr, FnCallExpr, Scope, AST};
+use shared::Timeframe;
+use std::collections::HashMap;
+
+/// Detect the automatic warmup requirement implied by typed Rhai indicator calls.
+///
+/// This scans the compiled strategy AST for `indicators::*` calls whose first
+/// argument is the new Market View candle-history API: `market.candles()` or
+/// `market.candles(tf)`. The returned value includes one extra candle of history
+/// for indicators with a detected period, matching the donor detector's rule.
+/// When no relevant indicator call is found, this returns `0` so the runtime
+/// minimum/default policy remains authoritative.
+pub fn detect_auto_warmup(ast: &AST, scope: &Scope<'_>) -> usize {
+    let mut max_hint: usize = 0;
+    let mut found_any = false;
+
+    ast.walk(&mut |nodes| {
+        let Some(rhai::ASTNode::Expr(Expr::FnCall(call, _))) = nodes.last() else {
+            return true;
+        };
+
+        if !is_indicators_call(call) || !first_arg_is_market_candles(call) {
+            return true;
+        }
+
+        if let Some(hint) = warmup_hint_for_call(call, scope) {
+            found_any = true;
+            max_hint = max_hint.max(hint);
+        }
+
+        true
+    });
+
+    if found_any {
+        max_hint + 1
+    } else {
+        0
+    }
+}
+
+/// Resolve the effective v1 warmup count.
+pub fn resolve_effective_warmup(
+    auto_detected_warmup: usize,
+    strategy_config_minimum_warmup: usize,
+    runtime_minimum_warmup: usize,
+) -> usize {
+    auto_detected_warmup
+        .max(strategy_config_minimum_warmup)
+        .max(runtime_minimum_warmup)
+}
+
+/// Per-timeframe-capable warmup plan used by the runtime.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WarmupPlan {
+    requirements_by_timeframe: HashMap<Timeframe, usize>,
+}
+
+impl WarmupPlan {
+    pub fn new(requirements_by_timeframe: HashMap<Timeframe, usize>) -> Self {
+        Self {
+            requirements_by_timeframe,
+        }
+    }
+
+    /// Build the v1 plan shape: the same resolved requirement assigned to every
+    /// configured timeframe.
+    pub fn same_requirement(config: &RuntimeConfig, requirement: usize) -> Self {
+        Self::new(
+            config
+                .configured_timeframes()
+                .into_iter()
+                .map(|timeframe| (timeframe, requirement))
+                .collect(),
+        )
+    }
+
+    pub fn requirement_for(&self, timeframe: Timeframe) -> Option<usize> {
+        self.requirements_by_timeframe.get(&timeframe).copied()
+    }
+
+    pub fn effective_requirement(&self) -> usize {
+        self.requirements_by_timeframe
+            .values()
+            .copied()
+            .max()
+            .unwrap_or(0)
+    }
+
+    pub fn requirements_by_timeframe(&self) -> &HashMap<Timeframe, usize> {
+        &self.requirements_by_timeframe
+    }
+}
+
+/// Resolve a v1 warmup plan for a strategy/run combination.
+///
+/// V1 assigns the same global effective count to every configured timeframe,
+/// while keeping the result keyed by timeframe for future per-timeframe rules.
+pub fn resolve_warmup_plan(
+    config: &RuntimeConfig,
+    strategy_config: &StrategyConfiguration,
+    ast: &AST,
+    scope: &Scope<'_>,
+    runtime_minimum_warmup: usize,
+) -> WarmupPlan {
+    let effective_warmup = resolve_effective_warmup(
+        detect_auto_warmup(ast, scope),
+        strategy_config.minimum_warmup(),
+        runtime_minimum_warmup,
+    );
+
+    WarmupPlan::same_requirement(config, effective_warmup)
+}
+
+fn is_indicators_call(call: &FnCallExpr) -> bool {
+    !call.namespace.is_empty()
+        && call
+            .namespace
+            .path
+            .first()
+            .map(|segment| segment.name.as_str() == "indicators")
+            .unwrap_or(false)
+}
+
+fn first_arg_is_market_candles(call: &FnCallExpr) -> bool {
+    call.args
+        .first()
+        .map(is_market_candles_expression)
+        .unwrap_or(false)
+}
+
+fn is_market_candles_expression(expr: &Expr) -> bool {
+    match expr {
+        Expr::Dot(binary, _, _) => {
+            matches!(&binary.lhs, Expr::Variable(info, _, _) if info.1.as_str() == "market")
+                && matches!(&binary.rhs, Expr::MethodCall(method, _) if method.name.as_str() == "candles" && method.args.len() <= 1)
+        }
+        _ => false,
+    }
+}
+
+fn warmup_hint_for_call(call: &FnCallExpr, scope: &Scope<'_>) -> Option<usize> {
+    fn arg(call: &FnCallExpr, index: usize, scope: &Scope<'_>) -> Option<usize> {
+        call.args
+            .get(index)
+            .and_then(|expr| resolve_period(expr, scope))
+    }
+
+    match call.name.as_str() {
+        // Single-period indicators.
+        "sma" | "ema" | "dema" | "tema" | "adx" | "rsi" | "cci" | "williams_r" | "roc" | "atr"
+        | "mfi" | "slope" | "bollinger" | "keltner" => arg(call, 1, scope),
+
+        // Stochastic variants.
+        "stochastic_fast" => arg(call, 1, scope),
+        "stochastic_slow" => arg(call, 1, scope).map(|period| period + 3),
+        "stochastic_full" => [1usize, 2, 3]
+            .into_iter()
+            .filter_map(|index| arg(call, index, scope))
+            .max(),
+
+        // Multi-period indicators.
+        "macd" => [1usize, 2, 3]
+            .into_iter()
+            .filter_map(|index| arg(call, index, scope))
+            .max(),
+
+        // Indicator-specific donor rules where numeric arguments are not
+        // warmup periods.
+        "ichimoku" => Some(52),
+        "sar" | "obv" => Some(1),
+        "vwap" | "volume_profile" | "pivot_points" | "fibonacci" => Some(0),
+
+        // Conservative fallback for future period-based indicators.
+        _ => call
+            .args
+            .iter()
+            .skip(1)
+            .filter_map(|expr| resolve_period(expr, scope))
+            .max(),
+    }
+}
+
+fn resolve_period(expr: &Expr, scope: &Scope<'_>) -> Option<usize> {
+    match expr {
+        Expr::IntegerConstant(value, _) => (*value > 0).then_some(*value as usize),
+        Expr::Variable(info, _, _) => scope
+            .get_value::<i64>(info.1.as_str())
+            .filter(|value| *value > 0)
+            .map(|value| value as usize),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        MarketInput, PortfolioState, PredeterminedStrategyHandler, RhaiStrategy, RuntimeConfig,
+        RuntimeEvent, SecondaryTimeframeConfig, StrategyDecision, Timeframe, TradingRuntime,
+    };
+    use shared::Candle;
+
+    fn load(source: &str) -> RhaiStrategy {
+        RhaiStrategy::load(source).expect("strategy should load")
+    }
+
+    fn source_with_on_tick(body: &str) -> String {
+        format!(
+            r#"
+fn on_tick(market, context) {{
+    {body}
+}}
+"#
+        )
+    }
+
+    fn candle(timeframe: Timeframe, close: f64, timestamp: i64) -> Candle {
+        Candle {
+            timestamp,
+            symbol: "BTC-USD".to_string(),
+            open: close,
+            high: close,
+            low: close,
+            close,
+            volume: 1.0,
+            timeframe,
+        }
+    }
+
+    #[test]
+    fn detects_sma_period_from_primary_market_candles() {
+        let source = source_with_on_tick(
+            r#"
+let slow = indicators::sma(market.candles(), 50);
+decision::hold()
+"#,
+        );
+        let strategy = load(&source);
+
+        assert_eq!(detect_auto_warmup(strategy.ast(), strategy.scope()), 51);
+    }
+
+    #[test]
+    fn resolves_top_level_constants_used_as_periods() {
+        let source = r#"
+const SLOW = 50;
+const FAST = 10;
+fn on_tick(market, context) {
+    let slow = indicators::sma(market.candles(), SLOW);
+    let fast = indicators::sma(market.candles(), FAST);
+    decision::hold()
+}
+"#;
+        let strategy = load(source);
+
+        assert_eq!(detect_auto_warmup(strategy.ast(), strategy.scope()), 51);
+    }
+
+    #[test]
+    fn detects_multiple_indicators_by_max_requirement() {
+        let source = r#"
+const MACD_SLOW = 26;
+fn on_tick(market, context) {
+    let macd = indicators::macd(market.candles(), 12, MACD_SLOW, 9);
+    let rsi = indicators::rsi(market.candles(), 14);
+    decision::hold()
+}
+"#;
+        let strategy = load(source);
+
+        assert_eq!(detect_auto_warmup(strategy.ast(), strategy.scope()), 27);
+    }
+
+    #[test]
+    fn detects_secondary_market_candles_indicator_period() {
+        let source = r#"
+const H1 = timeframe("1h");
+fn on_tick(market, context) {
+    let h1_slow = indicators::sma(market.candles(H1), 80);
+    decision::hold()
+}
+"#;
+        let strategy = load(source);
+
+        assert_eq!(detect_auto_warmup(strategy.ast(), strategy.scope()), 81);
+    }
+
+    #[test]
+    fn no_relevant_indicators_returns_zero_so_runtime_minimum_can_win() {
+        let source = source_with_on_tick("decision::hold()");
+        let strategy = load(&source);
+
+        assert_eq!(detect_auto_warmup(strategy.ast(), strategy.scope()), 0);
+    }
+
+    #[test]
+    fn old_candles_argument_shape_is_not_detected() {
+        let source = r#"
+fn on_tick(market, context) {
+    let old_shape = indicators::sma(candles, 200);
+    decision::hold()
+}
+"#;
+        let strategy = load(source);
+
+        assert_eq!(detect_auto_warmup(strategy.ast(), strategy.scope()), 0);
+    }
+
+    #[test]
+    fn strategy_config_minimum_warmup_wins_over_detected_and_runtime_minimum() {
+        let source = r#"
+fn strategy_config() {
+    strategy_config::new().with_minimum_warmup(100)
+}
+
+fn on_tick(market, context) {
+    let slow = indicators::sma(market.candles(), 30);
+    decision::hold()
+}
+"#;
+        let strategy = load(source);
+        let config = RuntimeConfig::single_timeframe("BTC-USD", Timeframe::minutes(1));
+        let plan = resolve_warmup_plan(
+            &config,
+            strategy.strategy_config(),
+            strategy.ast(),
+            strategy.scope(),
+            10,
+        );
+
+        assert_eq!(plan.requirement_for(Timeframe::minutes(1)), Some(100));
+    }
+
+    #[test]
+    fn runtime_minimum_warmup_wins_over_detected_and_strategy_minimum() {
+        let source = source_with_on_tick(
+            r#"
+let slow = indicators::sma(market.candles(), 30);
+decision::hold()
+"#,
+        );
+        let strategy = load(&source);
+        let config = RuntimeConfig::single_timeframe("BTC-USD", Timeframe::minutes(1));
+        let plan = resolve_warmup_plan(
+            &config,
+            strategy.strategy_config(),
+            strategy.ast(),
+            strategy.scope(),
+            120,
+        );
+
+        assert_eq!(plan.requirement_for(Timeframe::minutes(1)), Some(120));
+    }
+
+    #[test]
+    fn strategy_config_cannot_lower_detected_warmup() {
+        let source = r#"
+fn strategy_config() {
+    strategy_config::new().with_minimum_warmup(10)
+}
+
+fn on_tick(market, context) {
+    let slow = indicators::sma(market.candles(), 80);
+    decision::hold()
+}
+"#;
+        let strategy = load(source);
+        let config = RuntimeConfig::single_timeframe("BTC-USD", Timeframe::minutes(1));
+        let plan = resolve_warmup_plan(
+            &config,
+            strategy.strategy_config(),
+            strategy.ast(),
+            strategy.scope(),
+            0,
+        );
+
+        assert_eq!(plan.requirement_for(Timeframe::minutes(1)), Some(81));
+    }
+
+    #[test]
+    fn v1_plan_assigns_effective_requirement_to_every_configured_timeframe() {
+        let source = r#"
+const H1 = timeframe("1h");
+fn on_tick(market, context) {
+    let slow = indicators::sma(market.candles(H1), 80);
+    decision::hold()
+}
+"#;
+        let strategy = load(source);
+        let primary = Timeframe::minutes(1);
+        let secondary = Timeframe::hours(1);
+        let config = RuntimeConfig::with_secondary_configs(
+            "BTC-USD",
+            primary,
+            [SecondaryTimeframeConfig::required(secondary, 0)],
+        );
+        let plan = resolve_warmup_plan(
+            &config,
+            strategy.strategy_config(),
+            strategy.ast(),
+            strategy.scope(),
+            10,
+        );
+
+        assert_eq!(plan.requirement_for(primary), Some(81));
+        assert_eq!(plan.requirement_for(secondary), Some(81));
+    }
+
+    #[test]
+    fn runtime_uses_warmup_plan_requirements_by_timeframe() {
+        let primary = Timeframe::minutes(1);
+        let secondary = Timeframe::hours(1);
+        let config = RuntimeConfig::with_secondary_configs(
+            "BTC-USD",
+            primary,
+            [SecondaryTimeframeConfig::required(secondary, 0)],
+        );
+        let plan = WarmupPlan::new(HashMap::from([(primary, 1), (secondary, 2)]));
+        let strategy = PredeterminedStrategyHandler::from_decisions([StrategyDecision::hold()]);
+        let mut runtime =
+            TradingRuntime::with_warmup_plan(config, PortfolioState::new(1_000.0), plan, strategy);
+
+        let primary_step = runtime
+            .on_market_input(MarketInput::WarmupCandle(candle(primary, 100.0, 60_000)))
+            .expect("primary warmup should be accepted");
+        assert!(!primary_step
+            .events
+            .iter()
+            .any(|event| matches!(event, RuntimeEvent::WarmupCompleted { .. })));
+
+        let first_secondary_step = runtime
+            .on_market_input(MarketInput::WarmupCandle(candle(
+                secondary, 100.0, 3_600_000,
+            )))
+            .expect("secondary warmup should be accepted");
+        assert!(!first_secondary_step
+            .events
+            .iter()
+            .any(|event| matches!(event, RuntimeEvent::WarmupCompleted { .. })));
+
+        let second_secondary_step = runtime
+            .on_market_input(MarketInput::WarmupCandle(candle(
+                secondary, 101.0, 7_200_000,
+            )))
+            .expect("secondary warmup should be accepted");
+        assert!(second_secondary_step
+            .events
+            .iter()
+            .any(|event| matches!(event, RuntimeEvent::WarmupCompleted { .. })));
+    }
+}

--- a/trading-runtime/tests/market_input.rs
+++ b/trading-runtime/tests/market_input.rs
@@ -80,15 +80,16 @@ impl CountingStrategyHandler {
 }
 
 impl StrategyHandler for CountingStrategyHandler {
-    fn next_decision(
+    fn on_tick(
         &mut self,
-        _candle: &Candle,
-        _portfolio: &RuntimePortfolioSnapshot,
-    ) -> StrategyDecision {
+        _input: trading_runtime::StrategyTickInput<'_>,
+    ) -> trading_runtime::StrategyTickResult {
         *self.calls.borrow_mut() += 1;
-        self.decisions
-            .pop_front()
-            .unwrap_or_else(StrategyDecision::hold)
+        trading_runtime::StrategyTickResult::Decision(
+            self.decisions
+                .pop_front()
+                .unwrap_or_else(StrategyDecision::hold),
+        )
     }
 }
 

--- a/trading-runtime/tests/risk_exit_regressions.rs
+++ b/trading-runtime/tests/risk_exit_regressions.rs
@@ -2,8 +2,8 @@ use shared::{Candle, Position, PositionSide, Timeframe};
 use std::{cell::RefCell, rc::Rc};
 use trading_runtime::{
     ClosedPosition, ExecutionAction, ExitKind, MarketInput, PortfolioState, RiskExitKind,
-    RiskExitTriggered, RuntimeEvent, RuntimePortfolioSnapshot, RuntimeStep, StrategyDecision,
-    StrategyHandler, TradingRuntime,
+    RiskExitTriggered, RuntimeEvent, RuntimeStep, StrategyDecision, StrategyHandler,
+    TradingRuntime,
 };
 
 fn ohlc_candle(timestamp: i64, open: f64, high: f64, low: f64, close: f64) -> Candle {
@@ -51,13 +51,12 @@ struct CountingStrategyHandler {
 }
 
 impl StrategyHandler for CountingStrategyHandler {
-    fn next_decision(
+    fn on_tick(
         &mut self,
-        _candle: &Candle,
-        _portfolio: &RuntimePortfolioSnapshot,
-    ) -> StrategyDecision {
+        _input: trading_runtime::StrategyTickInput<'_>,
+    ) -> trading_runtime::StrategyTickResult {
         *self.calls.borrow_mut() += 1;
-        StrategyDecision::hold()
+        trading_runtime::StrategyTickResult::Decision(StrategyDecision::hold())
     }
 }
 

--- a/trading-runtime/tests/strategy_examples.rs
+++ b/trading-runtime/tests/strategy_examples.rs
@@ -1,0 +1,59 @@
+use std::path::{Path, PathBuf};
+
+use shared::Candle;
+use trading_runtime::{
+    MarketInput, PortfolioState, RhaiStrategy, RuntimeEvent, StrategyDecisionIntent, TradingRuntime,
+};
+
+fn strategies_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../strategies")
+}
+
+fn candle(close: f64, timestamp: i64) -> Candle {
+    Candle {
+        timestamp,
+        symbol: "TEST".to_string(),
+        open: close - 0.5,
+        high: close + 1.0,
+        low: close - 1.0,
+        close,
+        volume: 1_000.0,
+        timeframe: "1m".parse().expect("valid timeframe"),
+    }
+}
+
+fn load_example(name: &str) -> RhaiStrategy {
+    RhaiStrategy::load_file(strategies_dir().join(name)).expect("example strategy should load")
+}
+
+fn produced_intent(events: &[RuntimeEvent]) -> Option<StrategyDecisionIntent> {
+    events.iter().find_map(|event| match event {
+        RuntimeEvent::StrategyDecisionProduced { decision } => Some(decision.intent),
+        _ => None,
+    })
+}
+
+#[test]
+fn typed_strategy_examples_load() {
+    for strategy in ["sma_cross.rhai", "min_loss.rhai", "trendline_break.rhai"] {
+        load_example(strategy);
+    }
+}
+
+#[test]
+fn typed_strategy_examples_run_one_runtime_tick() {
+    for strategy in ["sma_cross.rhai", "min_loss.rhai", "trendline_break.rhai"] {
+        let strategy_handler = load_example(strategy);
+        let mut runtime = TradingRuntime::new(PortfolioState::new(10_000.0), 0, strategy_handler);
+
+        let step = runtime
+            .on_market_input(MarketInput::CompletedCandle(candle(100.0, 1)))
+            .expect("primary candle should be accepted");
+
+        assert_eq!(
+            produced_intent(&step.events),
+            Some(StrategyDecisionIntent::Hold),
+            "{strategy} should produce HOLD on its first example tick"
+        );
+    }
+}

--- a/trading-runtime/tests/strategy_tick_boundary.rs
+++ b/trading-runtime/tests/strategy_tick_boundary.rs
@@ -1,0 +1,134 @@
+use shared::{Candle, Timeframe};
+use std::{cell::RefCell, rc::Rc};
+use trading_runtime::{
+    ExecutionAction, MarketInput, PortfolioState, RuntimeEvent, StrategyDecision, StrategyError,
+    StrategyHandler, StrategyTickInput, StrategyTickResult, TradingRuntime,
+};
+
+fn candle(timestamp: i64, close: f64) -> Candle {
+    Candle {
+        timestamp,
+        symbol: "BTC-USD".into(),
+        open: close,
+        high: close,
+        low: close,
+        close,
+        volume: 1_000.0,
+        timeframe: Timeframe::minutes(1),
+    }
+}
+
+#[derive(Clone)]
+struct InspectingStrategyHandler {
+    seen_primary_timestamp: Rc<RefCell<Option<i64>>>,
+    seen_market_latest_timestamp: Rc<RefCell<Option<i64>>>,
+    seen_equity: Rc<RefCell<Option<f64>>>,
+}
+
+impl StrategyHandler for InspectingStrategyHandler {
+    fn on_tick(&mut self, input: StrategyTickInput<'_>) -> StrategyTickResult {
+        *self.seen_primary_timestamp.borrow_mut() = Some(input.primary_candle.timestamp);
+        *self.seen_market_latest_timestamp.borrow_mut() = input
+            .market
+            .latest_candle(input.market.primary_timeframe())
+            .map(|candle| candle.timestamp);
+        *self.seen_equity.borrow_mut() = Some(input.context.portfolio.current_equity);
+        let _state_handle = &input.context.state;
+
+        StrategyTickResult::Decision(StrategyDecision::hold())
+    }
+}
+
+#[test]
+fn fake_strategy_receives_primary_candle_market_view_and_portfolio_context() {
+    let seen_primary_timestamp = Rc::new(RefCell::new(None));
+    let seen_market_latest_timestamp = Rc::new(RefCell::new(None));
+    let seen_equity = Rc::new(RefCell::new(None));
+    let first = candle(1, 100.0);
+    let second = candle(2, 125.0);
+    let mut runtime = TradingRuntime::new(
+        PortfolioState::new(1_000.0),
+        0,
+        InspectingStrategyHandler {
+            seen_primary_timestamp: Rc::clone(&seen_primary_timestamp),
+            seen_market_latest_timestamp: Rc::clone(&seen_market_latest_timestamp),
+            seen_equity: Rc::clone(&seen_equity),
+        },
+    );
+
+    runtime
+        .on_market_input(MarketInput::CompletedCandle(first))
+        .unwrap();
+    let step = runtime
+        .on_market_input(MarketInput::CompletedCandle(second.clone()))
+        .unwrap();
+
+    assert_eq!(*seen_primary_timestamp.borrow(), Some(second.timestamp));
+    assert_eq!(
+        *seen_market_latest_timestamp.borrow(),
+        Some(second.timestamp)
+    );
+    assert_eq!(*seen_equity.borrow(), Some(1_000.0));
+    assert!(step.events.iter().any(|event| matches!(
+        event,
+        RuntimeEvent::StrategyDecisionProduced { decision }
+            if *decision == StrategyDecision::hold()
+    )));
+}
+
+#[derive(Clone)]
+struct ErrorStrategyHandler;
+
+impl StrategyHandler for ErrorStrategyHandler {
+    fn on_tick(&mut self, _input: StrategyTickInput<'_>) -> StrategyTickResult {
+        StrategyTickResult::Error(StrategyError::new("strategy exploded"))
+    }
+}
+
+#[test]
+fn fake_strategy_error_emits_diagnostic_and_does_not_plan_execution() {
+    let primary = candle(1, 100.0);
+    let mut runtime = TradingRuntime::new(PortfolioState::new(1_000.0), 0, ErrorStrategyHandler);
+
+    let step = runtime
+        .on_market_input(MarketInput::CompletedCandle(primary.clone()))
+        .unwrap();
+
+    assert_eq!(
+        step.events,
+        vec![
+            RuntimeEvent::MarketInputAccepted {
+                candle: primary.clone(),
+            },
+            RuntimeEvent::TradableCandleAccepted {
+                candle: primary.clone(),
+            },
+            RuntimeEvent::StrategyTickStarted {
+                candle: primary.clone(),
+            },
+            RuntimeEvent::StrategyError {
+                candle: primary,
+                error: StrategyError::new("strategy exploded"),
+            },
+            RuntimeEvent::StrategyTickCompleted,
+            RuntimeEvent::TradableCandleCompleted,
+        ]
+    );
+    assert!(!step.events.iter().any(|event| matches!(
+        event,
+        RuntimeEvent::StrategyDecisionProduced { .. }
+            | RuntimeEvent::ExecutionActionPlanned {
+                action: ExecutionAction::OpenLong { .. }
+                    | ExecutionAction::CloseLong
+                    | ExecutionAction::OpenShort { .. }
+                    | ExecutionAction::CloseShort
+                    | ExecutionAction::Noop
+                    | ExecutionAction::RiskExit { .. }
+                    | ExecutionAction::ForceClose,
+            }
+    )));
+    assert_eq!(
+        step.portfolio_snapshot,
+        PortfolioState::new(1_000.0).snapshot(100.0)
+    );
+}

--- a/trading-runtime/tests/trading_runtime.rs
+++ b/trading-runtime/tests/trading_runtime.rs
@@ -106,15 +106,16 @@ impl CountingStrategyHandler {
 }
 
 impl StrategyHandler for CountingStrategyHandler {
-    fn next_decision(
+    fn on_tick(
         &mut self,
-        _candle: &Candle,
-        _portfolio: &RuntimePortfolioSnapshot,
-    ) -> StrategyDecision {
+        _input: trading_runtime::StrategyTickInput<'_>,
+    ) -> trading_runtime::StrategyTickResult {
         *self.calls.borrow_mut() += 1;
-        self.decisions
-            .pop_front()
-            .unwrap_or_else(StrategyDecision::hold)
+        trading_runtime::StrategyTickResult::Decision(
+            self.decisions
+                .pop_front()
+                .unwrap_or_else(StrategyDecision::hold),
+        )
     }
 }
 


### PR DESCRIPTION
- **docs(strategy): document typed Rhai strategy API**
- **feat(runtime): introduce strategy tick boundary (#71)**
- **feat(runtime): add Rhai strategy loader (#72)**
- **feat(runtime): add typed Rhai decision API (#73)**
- **feat(runtime): add grouped Rhai strategy context (#74)**
- **feat(runtime): add Rhai primary market view (#75)**
- **feat(runtime): add typed strategy config extraction (#76)**
- **feat(runtime): add typed secondary Rhai market view (#77)**
- **feat(runtime): add Rhai market-view warmup detection (#78)**
- **feat(runtime): add typed anchored Rhai outputs (#79)**
- **docs(strategies): document typed Rhai runtime API (#80)**
